### PR TITLE
Replace -> type with general type application

### DIFF
--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -11,7 +11,7 @@
 
 import { Expression, functionArgs, SVar } from "./syntax";
 
-import { printType, TFunction, TNumber, TString, TVar, Type } from "./types";
+import { printType, TApplication, TNumber, TString, TVar, Type } from "./types";
 
 type TConstraint = [Type, Type];
 type TAssumption = [SVar, Type];
@@ -53,9 +53,9 @@ function infer(
       ];
       return {
         type: {
-          type: "function",
-          from: argtypes,
-          to: type
+          type: "application",
+          op: "->",
+          args: [...argtypes, type]
         },
         constraints: constraints.concat(newConstraints),
         assumptions: assumptions.filter(([v, _]) => !fnargs.includes(v))

--- a/packages/delisp-core/src/types.ts
+++ b/packages/delisp-core/src/types.ts
@@ -10,10 +10,10 @@ export interface TString {
   type: "string";
 }
 
-export interface TFunction {
-  type: "function";
-  from: Type[];
-  to: Type;
+export interface TApplication {
+  type: "application";
+  op: string;
+  args: Type[];
 }
 
 export interface TVar {
@@ -21,14 +21,12 @@ export interface TVar {
   name: string;
 }
 
-export type Type = TNumber | TString | TFunction | TVar;
+export type Type = TNumber | TString | TApplication | TVar;
 
 export function printType(type: Type): string {
   switch (type.type) {
-    case "function":
-      return `(-> (${type.from.map(printType).join(" ")}) ${printType(
-        type.to
-      )})`;
+    case "application":
+      return `(${type.op} ${type.args.map(printType).join(" ")})`;
     case "number":
       return "number";
     case "string":


### PR DESCRIPTION
This will allow us to introduce new type operators easily without
having to change the recursion mechanism of the type inference for
example.