### PR TITLE
FIX: Reader not parsing Symbol correctly

### DIFF
--- a/packages/delisp-core/__tests__/reader.ts
+++ b/packages/delisp-core/__tests__/reader.ts
@@ -40,6 +40,18 @@ describe("Reader", () => {
       name: "xyz",
       location: { start: 2, end: 5 }
     });
+
+    expect(readFromString("  a2  ")).toMatchObject({
+      type: "symbol",
+      name: "a2",
+      location: { start: 2, end: 4 }
+    });
+
+    expect(readFromString("  $bc  ")).toMatchObject({
+      type: "symbol",
+      name: "$bc",
+      location: { start: 2, end: 5 }
+    });
   });
 
   it("should read lists", () => {

--- a/packages/delisp-core/src/reader.ts
+++ b/packages/delisp-core/src/reader.ts
@@ -28,7 +28,7 @@ function spaced<A>(x: Parser<A>) {
 }
 
 const alphanumeric = character().chain(char => {
-  if (/[a-zA-Z0-1]/.test(char)) {
+  if (/[a-zA-Z0-9]/.test(char)) {
     return Parser.of(char);
   } else {
     return Parser.fail("an alphanumeric character");


### PR DESCRIPTION
Added breaking test case: `a2` results in a symbol with name `a`.