### PR TITLE
Module reading and compiling

### DIFF
--- a/packages/delisp-core/__tests__/readModule.ts
+++ b/packages/delisp-core/__tests__/readModule.ts
@@ -1,0 +1,39 @@
+import { readModule } from "../src/index";
+
+describe("ReadModule", () => {
+  it("should read all syntaxes", () => {
+    expect(readModule(" (sum 1 2 3) (+ 4 5) (inc 6) ")).toMatchObject({
+      type: "module",
+      body: [
+        {
+          type: "function-call",
+          fn: {
+            type: "variable-reference",
+            variable: "sum"
+          },
+          args: [
+            { type: "number", value: 1 },
+            { type: "number", value: 2 },
+            { type: "number", value: 3 }
+          ]
+        },
+        {
+          type: "function-call",
+          fn: {
+            type: "variable-reference",
+            variable: "+"
+          },
+          args: [{ type: "number", value: 4 }, { type: "number", value: 5 }]
+        },
+        {
+          type: "function-call",
+          fn: {
+            type: "variable-reference",
+            variable: "inc"
+          },
+          args: [{ type: "number", value: 6 }]
+        }
+      ]
+    });
+  });
+});

--- a/packages/delisp-core/__tests__/reader.ts
+++ b/packages/delisp-core/__tests__/reader.ts
@@ -1,5 +1,4 @@
-import { getParserError } from "../src/parser-combinators";
-import { readFromString } from "../src/reader";
+import { readAllFromString, readFromString } from "../src/reader";
 
 describe("Reader", () => {
   it("should read numbers", () => {
@@ -116,6 +115,25 @@ describe("Reader", () => {
     });
   });
 
+  it("should read multiple S-expressions", () => {
+    expect(readAllFromString("(x 1 2)(y 3)")).toMatchObject([
+      { type: "list" },
+      { type: "list" }
+    ]);
+
+    expect(readAllFromString(" (x 1 2) (y 3) ")).toMatchObject([
+      { type: "list" },
+      { type: "list" }
+    ]);
+
+    expect(
+      readAllFromString(`
+      (x 1 2)
+      (y 3)
+    `)
+    ).toMatchObject([{ type: "list" }, { type: "list" }]);
+  });
+
   describe("Error messages", () => {
     const failedRead = (x: string) => {
       try {
@@ -157,10 +175,24 @@ describe("Reader", () => {
       }
     };
 
+    const readAll = (x: string) => {
+      try {
+        readAllFromString(x);
+        return undefined;
+      } catch (err) {
+        return err.incomplete;
+      }
+    };
+
     expect(read("(1 2 3")).toBe(true);
     expect(read(")")).toBe(false);
     expect(read('"foo')).toBe(true);
     expect(read('"ab\\xyz"')).toBe(false);
     expect(read('"abc\\')).toBe(true);
+
+    expect(readAll("(1 2 3)(4 5")).toBe(true);
+    expect(readAll("(1 2 3)4 5)")).toBe(false);
+    expect(readAll("((1 2 3)")).toBe(true);
+    expect(readAll("(1 2 3))")).toBe(false);
   });
 });

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -1,6 +1,6 @@
-import { printHighlightedExpr } from "./error-report";
 import {
   Expression,
+  Module,
   SDefinition,
   SFunction,
   SFunctionCall,
@@ -116,24 +116,28 @@ function compileTopLevel(syntax: Syntax, env: Environment): JSAST {
   }
 }
 
-export function compileModule(syntax: Syntax): JSAST {
+function compileModule(module: Module): JSAST {
   return {
     type: "File",
     program: {
       type: "Program",
       sourceType: "module",
-      body: [
-        {
-          type: "ExpressionStatement",
-          expression: compileTopLevel(syntax, {})
-        }
-      ]
+      body: module.body.map((syntax: Syntax) => ({
+        type: "ExpressionStatement",
+        expression: compileTopLevel(syntax, {})
+      }))
     }
   };
 }
 
 export function compileToString(syntax: Syntax): string {
-  const ast = compileModule(syntax);
+  const ast = compileModule({ type: "module", body: [syntax] });
+  debug("jsast:", ast);
+  return recast.print(ast).code;
+}
+
+export function compileModuleToString(module: Module): string {
+  const ast = compileModule(module);
   debug("jsast:", ast);
   return recast.print(ast).code;
 }

--- a/packages/delisp-core/src/index.ts
+++ b/packages/delisp-core/src/index.ts
@@ -1,7 +1,7 @@
 import { convert as convertSyntax } from "./convert";
 import { convert as convertType } from "./convertType";
-import { readFromString } from "./reader";
-import { Syntax } from "./syntax";
+import { readAllFromString, readFromString } from "./reader";
+import { Module, Syntax } from "./syntax";
 import { Type } from "./types";
 
 export { compileToString } from "./compiler";
@@ -13,6 +13,13 @@ export { isDeclaration } from "./syntax";
 
 export function readSyntax(source: string): Syntax {
   return convertSyntax(readFromString(source));
+}
+
+export function readModule(str: string): Module {
+  return {
+    type: "module",
+    body: readAllFromString(str).map(convertSyntax)
+  };
 }
 
 export function readType(source: string): Type {

--- a/packages/delisp-core/src/parser-combinators.ts
+++ b/packages/delisp-core/src/parser-combinators.ts
@@ -227,6 +227,22 @@ export const character = (expected?: string) => {
   });
 };
 
+export const endOfInput = new Parser<void>(input => {
+  const [char] = input.readChars(1);
+  return char === ""
+    ? {
+        status: "success",
+        value: undefined,
+        moreInput: input
+      }
+    : {
+        status: "error",
+        reasons: [],
+        incomplete: false,
+        offset: input.offset
+      };
+});
+
 //
 // Error reporting
 //

--- a/packages/delisp-core/src/parser-combinators.ts
+++ b/packages/delisp-core/src/parser-combinators.ts
@@ -132,9 +132,17 @@ export class Parser<A> {
   //
   // Run a parser against a string
   //
-  parse(x: string) {
+  parse(x: string): A {
     const input = new Input(x);
-    return this.run(input);
+    const result = this.run(input);
+    if (result.status === "success") {
+      return result.value;
+    } else {
+      const message = getParserError(x, result);
+      const err = new Error(message);
+      (err as any).incomplete = result.incomplete;
+      throw err;
+    }
   }
 }
 

--- a/packages/delisp-core/src/reader.ts
+++ b/packages/delisp-core/src/reader.ts
@@ -13,7 +13,6 @@ import {
   delimited,
   delimitedMany,
   endOfInput,
-  getParserError,
   many,
   Parser,
   until
@@ -169,28 +168,12 @@ const sexpr: Parser<ASExpr> = spaced(
 const sexprs: Parser<ASExpr[]> = until(endOfInput, sexpr);
 
 export function readAllFromString(str: string): ASExpr[] {
-  const result = sexprs.parse(str);
-  if (result.status === "success") {
-    return result.value;
-  } else {
-    const message = getParserError(str, result);
-    const err = new Error(message);
-    (err as any).incomplete = result.incomplete;
-    throw err;
-  }
+  return sexprs.parse(str);
 }
 
 //
 // Parser a Delisp expression from a string
 //
 export function readFromString(str: string): ASExpr {
-  const result = sexpr.parse(str);
-  if (result.status === "success") {
-    return result.value;
-  } else {
-    const message = getParserError(str, result);
-    const err = new Error(message);
-    (err as any).incomplete = result.incomplete;
-    throw err;
-  }
+  return sexpr.parse(str);
 }

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -71,3 +71,8 @@ export type Syntax = Expression | Declaration;
 export function isDeclaration(syntax: Syntax): syntax is Declaration {
   return syntax.type === "definition";
 }
+
+export interface Module {
+  type: "module";
+  body: Syntax[];
+}


### PR DESCRIPTION
- Add a new `Module` type (wrapping `Syntax[]`) 
- Add `readAllFromString` in reader, consuming the full input and returning `ASExpr[]`
- Add `readModule` in the top level (combining the above 2 to do `string -> ASExpr[] -> Syntax[] -> Module`)
- Update compiler to ~accept both `Syntax` and `Module` as input~ also compile Modules

Fixes #9