### PR TITLE
Fix compiler in the compilation of nested lambda functions

### DIFF
--- a/packages/delisp-core/__tests__/eval.ts
+++ b/packages/delisp-core/__tests__/eval.ts
@@ -33,6 +33,17 @@ describe("Evaluation", () => {
     it("should be able to be called", () => {
       expect(evaluateString("((lambda (x y) y) 4 5)")).toBe(5);
     });
+
+    // Regression
+    it("different argument names should not shadow", () => {
+      expect(
+        evaluateString(`
+((lambda (x)
+  ((lambda (y) x) 11))
+ 33)
+`)
+      ).toBe(33);
+    });
   });
 
   describe("Let bindings", () => {

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -20,11 +20,19 @@ interface Environment {
   [symbol: string]: string;
 }
 
+// Convert a Delisp variable name to Javascript. This function should
+// be injective so there is no collisions and the output should be a
+// valid variable name.
+function varnameToJS(x: string): string {
+  // TODO: make it always a valid JS name!
+  return x;
+}
+
 function compileLambda(fn: SFunction, env: Environment): JSAST {
   const newEnv = fn.lambdaList.reduce(
     (e, param, ix) => ({
       ...e,
-      [param.variable]: `p${ix}`
+      [param.variable]: varnameToJS(param.variable)
     }),
     env
   );

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -10,6 +10,8 @@ import {
   Syntax
 } from "./syntax";
 
+import { varnameToJS } from "./compiler/jsvariable";
+
 import * as recast from "recast";
 
 import createDebug from "debug";
@@ -23,10 +25,6 @@ interface Environment {
 // Convert a Delisp variable name to Javascript. This function should
 // be injective so there is no collisions and the output should be a
 // valid variable name.
-function varnameToJS(x: string): string {
-  // TODO: make it always a valid JS name!
-  return x;
-}
 
 function compileLambda(fn: SFunction, env: Environment): JSAST {
   const newEnv = fn.lambdaList.reduce(

--- a/packages/delisp-core/src/compiler/__snapshots__/jsvariable.spec.ts.snap
+++ b/packages/delisp-core/src/compiler/__snapshots__/jsvariable.spec.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Variable name translation should escape delisp variable characters not allowed in Javascript 1`] = `
+Array [
+  Object {
+    "delisp": "$",
+    "js": "$dollar$",
+  },
+  Object {
+    "delisp": "+",
+    "js": "$plus$",
+  },
+  Object {
+    "delisp": "-",
+    "js": "$minus$",
+  },
+  Object {
+    "delisp": "*",
+    "js": "$star$",
+  },
+  Object {
+    "delisp": "/",
+    "js": "$div$",
+  },
+  Object {
+    "delisp": "int?",
+    "js": "int$q$",
+  },
+  Object {
+    "delisp": "a->b",
+    "js": "a$minus$$gt$b",
+  },
+  Object {
+    "delisp": "<=",
+    "js": "$lt$$eq$",
+  },
+  Object {
+    "delisp": "%compile",
+    "js": "$percent$compile",
+  },
+  Object {
+    "delisp": "!foo",
+    "js": "$bang$foo",
+  },
+  Object {
+    "delisp": "&foo",
+    "js": "$amp$foo",
+  },
+]
+`;

--- a/packages/delisp-core/src/compiler/jsvariable.spec.ts
+++ b/packages/delisp-core/src/compiler/jsvariable.spec.ts
@@ -1,0 +1,28 @@
+import { varnameToJS } from "./jsvariable";
+
+describe("Variable name translation", () => {
+  it("should escape delisp variable characters not allowed in Javascript", () => {
+    const cases = [
+      "$",
+      "+",
+      "-",
+      "*",
+      "/",
+      "int?",
+      "a->b",
+      "<=",
+      "%compile",
+      "!foo",
+      "&foo"
+    ];
+    const result = cases.map(v => ({
+      delisp: v,
+      js: varnameToJS(v)
+    }));
+    return expect(result).toMatchSnapshot();
+  });
+
+  it("should fail for not allowed characters", () => {
+    expect(() => varnameToJS("``")).toThrow();
+  });
+});

--- a/packages/delisp-core/src/compiler/jsvariable.ts
+++ b/packages/delisp-core/src/compiler/jsvariable.ts
@@ -1,0 +1,40 @@
+export function varnameToJS(x: string): string {
+  const escapes = new Map(
+    Object.entries({
+      "!": "bang",
+      "@": "at",
+      "#": "sharp",
+      $: "dollar",
+      "%": "percent",
+      "^": "caret",
+      "&": "amp",
+      "*": "star",
+      "<": "lt",
+      ">": "gt",
+      "+": "plus",
+      "-": "minus",
+      "/": "div",
+      "~": "tilde",
+      "?": "q",
+      "=": "eq"
+    })
+  );
+  // Instead of escaping specific characters, we have a list of
+  // allowed characters explicitly! That should make easier for us to
+  // catch issues in the future.
+  return x
+    .split("")
+    .map(ch => {
+      if (/[a-zA-Z0-9_]/.test(ch)) {
+        return ch;
+      } else if (escapes.has(ch)) {
+        const replacement: string = escapes.get(ch)!;
+        return "$" + replacement + "$";
+      } else {
+        throw new Error(
+          `Error: the variable ${x} contained a non-allowed character ${ch}.`
+        );
+      }
+    })
+    .join("");
+}

--- a/packages/delisp-core/src/reader.ts
+++ b/packages/delisp-core/src/reader.ts
@@ -102,6 +102,11 @@ const stringP = delimitedMany(doubleQuote, stringChar, doubleQuote)
 const symbol: Parser<ASExpr> = atLeastOne(
   alternatives(
     alphanumeric,
+    // Those special characters are valid in Delisp symbols.
+    //
+    // If you want to change this list, please remmeber checking the
+    // compiler and ensuring that it is able to generate JS variables
+    // for those names.
     character("!"),
     character("@"),
     character("#"),
@@ -116,7 +121,8 @@ const symbol: Parser<ASExpr> = atLeastOne(
     character("-"),
     character("/"),
     character("~"),
-    character("?")
+    character("?"),
+    character("=")
   )
 )
   .map(


### PR DESCRIPTION
To understand the issue, consider how the test case was compiled:

```lisp
((lambda (x)
  ((lambda (y) x) 11))
  33)
```

compiled to

```javascript
(function (p1) {
  (function (p1) {
    return p1
  })(11)
})(33)
```

So it is important for the compiler not to accidentally shadow variables in the generated code.

By introducing `varnameToJS`, and the injective property we'll require,  target JS variables will only shadow if the variables also shadow in the source.