### PR TITLE
Make the compiler tests fail on unexpected success

### DIFF
--- a/packages/delisp-core/__tests__/compiler.ts
+++ b/packages/delisp-core/__tests__/compiler.ts
@@ -5,13 +5,18 @@ import { compileToString } from "../src/compiler";
 describe("Compiler", () => {
   describe("Error messages", () => {
     function compileError(str: string): string {
+      let result: string | undefined;
       try {
         const sexpr = readFromString(str);
         const syntax = convert(sexpr);
         compileToString(syntax);
-        throw new Error(`FATAL: EXPRESSION DID NOT FAIL TO COMPILE.`);
       } catch (err) {
-        return err.message;
+        result = err.message;
+      }
+      if (result) {
+        return result;
+      } else {
+        throw new Error(`FATAL: EXPRESSION DID NOT FAIL TO COMPILE.`);
       }
     }
 


### PR DESCRIPTION
if a valid expression is passed to compilerError, the test will fail.