### PR TITLE
Inline compilation

### DIFF
--- a/packages/delisp-core/src/compiler/inline-primitives.ts
+++ b/packages/delisp-core/src/compiler/inline-primitives.ts
@@ -1,0 +1,94 @@
+import * as JS from "estree";
+import { range } from "../utils";
+
+type InlineHandler = (args: JS.Expression[]) => JS.Expression;
+
+interface InlinePrim {
+  nargs: number;
+  handle: InlineHandler;
+}
+
+const inlinefuncs = new Map<string, InlinePrim>();
+
+function defineInlinePrimitive(
+  name: string,
+  nargs: number,
+  handle: InlineHandler
+) {
+  return inlinefuncs.set(name, { nargs, handle });
+}
+
+export function isInlinePrimitive(name: string) {
+  return inlinefuncs.has(name);
+}
+
+export function findInlinePrimitive(name: string): InlinePrim {
+  const prim = inlinefuncs.get(name);
+  if (!prim) {
+    throw new Error(`${name} is not an primitive inline function call`);
+  }
+  return prim;
+}
+
+/** Compile a inline primitive with a set of parameters.
+ *
+ * @description If `position` is not a function call, a wrapper
+ * function will be created so the inlined primitive can be used as a
+ * function.
+ *
+ */
+export function compileInlinePrimitive(
+  name: string,
+  args: JS.Expression[],
+  position: "funcall" | "value"
+): JS.Expression {
+  const prim = findInlinePrimitive(name);
+  if (position === "funcall" || prim.nargs === 0) {
+    return prim.handle(args);
+  } else {
+    const identifiers = range(prim.nargs).map(
+      (i): JS.Identifier => ({
+        type: "Identifier",
+        name: `x${i}`
+      })
+    );
+    return {
+      type: "ArrowFunctionExpression",
+      params: identifiers,
+      body: prim.handle(identifiers),
+      expression: true
+    };
+  }
+}
+
+defineInlinePrimitive("true", 0, () => {
+  return {
+    type: "Literal",
+    value: true
+  };
+});
+
+defineInlinePrimitive("false", 0, () => {
+  return {
+    type: "Literal",
+    value: false
+  };
+});
+
+defineInlinePrimitive("+", 2, args => {
+  return {
+    type: "BinaryExpression",
+    operator: "+",
+    left: args[0],
+    right: args[1]
+  };
+});
+
+defineInlinePrimitive("*", 2, args => {
+  return {
+    type: "BinaryExpression",
+    operator: "*",
+    left: args[0],
+    right: args[1]
+  };
+});

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -21,6 +21,8 @@ import { Monotype, TVar, Type } from "./types";
 import { unify } from "./unify";
 import { difference, flatten, intersection, mapObject, union } from "./utils";
 
+import { getInlinePrimitiveTypes } from "./compiler/inline-primitives";
+
 import primitives from "./primitives";
 
 // The type inference process is split in two stages. Firstly, `infer`
@@ -409,7 +411,10 @@ function solve(
   }
 }
 
-const defaultTypeEnvironment = mapObject(primitives, prim => prim.type);
+const defaultTypeEnvironment: TypeEnvironment = {
+  ...getInlinePrimitiveTypes(),
+  ...mapObject(primitives, prim => prim.type)
+};
 
 export function inferType(
   expr: Expression,

--- a/packages/delisp-core/src/utils.ts
+++ b/packages/delisp-core/src/utils.ts
@@ -51,3 +51,8 @@ export function mapObject<A, B>(
   }
   return out;
 }
+
+/** Return an array with elements from 0 up to n (not included). */
+export function range(n: number) {
+  return new Array(n).fill(0).map((_, i) => i);
+}

--- a/packages/delisp-runtime/src/primitives.ts
+++ b/packages/delisp-runtime/src/primitives.ts
@@ -13,16 +13,6 @@ const prims: Primitives = {
   //   }
   // },
 
-  true: {
-    type: "boolean",
-    value: true
-  },
-
-  false: {
-    type: "boolean",
-    value: false
-  },
-
   not: {
     type: "(-> boolean boolean)",
     value: (a: boolean) => !a
@@ -41,16 +31,6 @@ const prims: Primitives = {
   "<": {
     type: "(-> number number boolean)",
     value: (a: number, b: number) => a < b
-  },
-
-  "+": {
-    type: "(-> number number number)",
-    value: (a: number, b: number) => a + b
-  },
-
-  "*": {
-    type: "(-> number number number)",
-    value: (a: number, b: number) => a * b
   },
 
   nil: {


### PR DESCRIPTION
**To merge after #24 and #25**

This pull request introduces compilation of inline primitives. For example, `(+ x 2)` will be compiled as ` x + 2`.

When used _not_ of a function call, a wrapper function will be added, so they can be used as first-class values, For example, `(map +)` generates:
```javascript
env["map"]((x0, x1) => x0 + x1);
```
