### PR TITLE
WIP - Improve type errors

### DIFF
--- a/packages/delisp-core/__tests__/read-module.ts
+++ b/packages/delisp-core/__tests__/read-module.ts
@@ -9,7 +9,7 @@ describe("ReadModule", () => {
           type: "function-call",
           fn: {
             type: "variable-reference",
-            variable: "sum"
+            name: "sum"
           },
           args: [
             { type: "number", value: 1 },
@@ -21,7 +21,7 @@ describe("ReadModule", () => {
           type: "function-call",
           fn: {
             type: "variable-reference",
-            variable: "+"
+            name: "+"
           },
           args: [{ type: "number", value: 4 }, { type: "number", value: 5 }]
         },
@@ -29,7 +29,7 @@ describe("ReadModule", () => {
           type: "function-call",
           fn: {
             type: "variable-reference",
-            variable: "inc"
+            name: "inc"
           },
           args: [{ type: "number", value: 6 }]
         }

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -79,9 +79,9 @@ function compileFunctionCall(
   const compiledArgs = funcall.args.map(arg => compile(arg, env));
   if (
     funcall.fn.type === "variable-reference" &&
-    isInlinePrimitive(funcall.fn.variable)
+    isInlinePrimitive(funcall.fn.name)
   ) {
-    return compileInlinePrimitive(funcall.fn.variable, compiledArgs, "funcall");
+    return compileInlinePrimitive(funcall.fn.name, compiledArgs, "funcall");
   } else {
     return {
       type: "CallExpression",
@@ -95,12 +95,12 @@ function compileVariable(
   ref: SVariableReference,
   env: Environment
 ): JS.Expression {
-  if (isInlinePrimitive(ref.variable)) {
-    return compileInlinePrimitive(ref.variable, [], "value");
-  } else if (ref.variable in env) {
+  if (isInlinePrimitive(ref.name)) {
+    return compileInlinePrimitive(ref.name, [], "value");
+  } else if (ref.name in env) {
     return {
       type: "Identifier",
-      name: env[ref.variable]
+      name: env[ref.name]
     };
   } else {
     return {
@@ -112,7 +112,7 @@ function compileVariable(
       },
       property: {
         type: "Literal",
-        value: ref.variable
+        value: ref.name
       }
     };
   }

--- a/packages/delisp-core/src/convert-type.ts
+++ b/packages/delisp-core/src/convert-type.ts
@@ -19,26 +19,34 @@ function convertList(expr: ASExprList): Monotype {
   const [op, ...args] = expr.elements;
 
   if (op.type !== "symbol") {
-    throw new Error(printHighlightedExpr("Expected symbol as operator", expr));
+    throw new Error(
+      printHighlightedExpr("Expected symbol as operator", expr.location)
+    );
   }
 
   switch (op.name) {
     case "->":
       if (args.length < 1) {
         throw new Error(
-          printHighlightedExpr("Expected at least 1 argument", op, true)
+          printHighlightedExpr(
+            "Expected at least 1 argument",
+            op.location,
+            true
+          )
         );
       }
       break;
     case "list":
       if (args.length !== 1) {
         throw new Error(
-          printHighlightedExpr("Expected exactly 1 argument", op)
+          printHighlightedExpr("Expected exactly 1 argument", op.location)
         );
       }
       break;
     default:
-      throw new Error(printHighlightedExpr("Unknown type constructor", op));
+      throw new Error(
+        printHighlightedExpr("Unknown type constructor", op.location)
+      );
   }
 
   return {
@@ -55,6 +63,6 @@ export function convert(expr: ASExpr): Monotype {
     case "symbol":
       return convertSymbol(expr);
     default:
-      throw new Error(printHighlightedExpr("Not a valid type", expr));
+      throw new Error(printHighlightedExpr("Not a valid type", expr.location));
   }
 }

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -227,7 +227,7 @@ export function convertExpr(expr: ASExpr): Expression {
     case "symbol":
       return {
         type: "variable-reference",
-        variable: expr.name,
+        name: expr.name,
         location: expr.location,
         info: {}
       };

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -29,7 +29,9 @@ function defineToplevel(name: string, fn: (expr: ASExprList) => Declaration) {
 
 function parseLambdaList(x: ASExpr): LambdaList {
   if (x.type !== "list") {
-    throw new Error(printHighlightedExpr("Expected a list of arguments", x));
+    throw new Error(
+      printHighlightedExpr("Expected a list of arguments", x.location)
+    );
   }
 
   x.elements.forEach(arg => {
@@ -37,7 +39,7 @@ function parseLambdaList(x: ASExpr): LambdaList {
       throw new Error(
         printHighlightedExpr(
           "A list of arguments should be made of symbols",
-          arg
+          arg.location
         )
       );
     }
@@ -52,7 +54,7 @@ function parseLambdaList(x: ASExpr): LambdaList {
       throw new Error(
         printHighlightedExpr(
           "There is another argument with the same name",
-          duplicated
+          duplicated.location
         )
       );
     }
@@ -66,10 +68,11 @@ function parseLambdaList(x: ASExpr): LambdaList {
 
 defineConversion("if", expr => {
   if (expr.elements.length !== 4) {
+    const lastExpr = last(expr.elements) as ASExpr; // we know it is not empty!
     throw new Error(
       printHighlightedExpr(
         `'if' needs exactly 3 arguments, got ${expr.elements.length}`,
-        last(expr.elements) as ASExpr, // we know it is not empty!
+        lastExpr.location,
         true
       )
     );
@@ -89,10 +92,11 @@ defineConversion("lambda", expr => {
   const [lambda, ...args] = expr.elements;
 
   if (args.length !== 2) {
+    const lastExpr = last([lambda, ...args]) as ASExpr; // we know it is not empty!
     throw new Error(
       printHighlightedExpr(
         `'lambda' needs exactly 2 arguments, got ${args.length}`,
-        last([lambda, ...args]) as ASExpr, // we know it is not empty!
+        lastExpr.location,
         true
       )
     );
@@ -109,7 +113,7 @@ defineConversion("lambda", expr => {
 function parseLetBindings(bindings: ASExpr): SLetBinding[] {
   if (bindings.type !== "list") {
     throw new Error(
-      printHighlightedExpr(`'let' bindings should be a list`, bindings)
+      printHighlightedExpr(`'let' bindings should be a list`, bindings.location)
     );
   }
 
@@ -118,17 +122,19 @@ function parseLetBindings(bindings: ASExpr): SLetBinding[] {
   bindings.elements.forEach(binding => {
     if (binding.type !== "list") {
       throw new Error(
-        printHighlightedExpr(`'let' binding should be a list`, binding)
+        printHighlightedExpr(`'let' binding should be a list`, binding.location)
       );
     }
     if (binding.elements.length !== 2) {
-      throw new Error(printHighlightedExpr(`ill-formed let binding`, binding));
+      throw new Error(
+        printHighlightedExpr(`ill-formed let binding`, binding.location)
+      );
     }
 
     const [name, value] = binding.elements;
 
     if (name.type !== "symbol") {
-      throw new Error(printHighlightedExpr(`expected a symbol`, name));
+      throw new Error(printHighlightedExpr(`expected a symbol`, name.location));
     }
 
     output.push({
@@ -145,10 +151,12 @@ defineConversion("let", expr => {
   const [_let, ...args] = expr.elements;
 
   if (args.length !== 2) {
+    const lastExpr = last([_let, ...args]) as ASExpr; // we know it is not empty!
+
     throw new Error(
       printHighlightedExpr(
         `'let' needs exactly 2 arguments, got ${args.length}`,
-        last([_let, ...args]) as ASExpr, // we know it is not empty!
+        lastExpr.location,
         true
       )
     );
@@ -167,10 +175,11 @@ defineToplevel("define", expr => {
   const [define, ...args] = expr.elements;
 
   if (args.length !== 2) {
+    const lastExpr = last([define, ...args]) as ASExpr;
     throw new Error(
       printHighlightedExpr(
         `'define' needs exactly 2 arguments, got ${args.length}`,
-        last([define, ...args]) as ASExpr,
+        lastExpr.location,
         true
       )
     );
@@ -180,7 +189,7 @@ defineToplevel("define", expr => {
 
   if (variable.type !== "symbol") {
     throw new Error(
-      printHighlightedExpr("'define' expected a symbol", variable)
+      printHighlightedExpr("'define' expected a symbol", variable.location)
     );
   }
 
@@ -195,7 +204,7 @@ defineToplevel("define", expr => {
 function convertList(list: ASExprList): Expression {
   if (list.elements.length === 0) {
     throw new Error(
-      printHighlightedExpr("Empty list is not a function call", list)
+      printHighlightedExpr("Empty list is not a function call", list.location)
     );
   }
 
@@ -240,7 +249,7 @@ export function convert(expr: ASExpr): Syntax {
   if (expr.type === "list") {
     if (expr.elements.length === 0) {
       throw new Error(
-        printHighlightedExpr("Empty list is not a function call", expr)
+        printHighlightedExpr("Empty list is not a function call", expr.location)
       );
     }
 

--- a/packages/delisp-core/src/error-report.ts
+++ b/packages/delisp-core/src/error-report.ts
@@ -2,7 +2,7 @@
  * Report errors in a user-friendly way
  */
 
-import { ASExpr } from "./sexpr";
+import { Location } from "./input";
 
 function repeatChar(ch: string, n: number): string {
   return Array(n)
@@ -38,10 +38,10 @@ export function printHighlightedSource(
 /** Print a error message with expr highlighted. */
 export function printHighlightedExpr(
   message: string,
-  expr: ASExpr,
+  location: Location,
   end = false
 ) {
-  const source = expr.location.input.toString();
-  const offset = end ? expr.location.end : expr.location.start;
+  const source = location.input.toString();
+  const offset = end ? location.end : location.start;
   return printHighlightedSource(message, source, offset);
 }

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -18,6 +18,8 @@ import {
   Syntax
 } from "./syntax";
 
+import { printType } from "./type-utils";
+
 import { printHighlightedExpr } from "./error-report";
 
 import { applySubstitution, Substitution } from "./type-substitution";
@@ -600,7 +602,17 @@ function solve(
           );
         case "unify-mismatch-error":
           throw new Error(
-            printHighlightedExpr("Type mismatch", constraint.expr.location)
+            printHighlightedExpr(
+              `Type mismatch
+
+${printType(applySubstitution(constraint.expr.info.type, solution))}
+
+vs.
+
+${printType(applySubstitution(constraint.t, solution))}
+`,
+              constraint.expr.location
+            )
           );
         default:
           // Adding a default clause here makes Typescript detects

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -201,9 +201,9 @@ function infer(
       // the new function type we have created.
       const newConstraints: TConstraint[] = [
         ...assumptions
-          .filter(v => fnargs.includes(v.variable))
+          .filter(v => fnargs.includes(v.name))
           .map(v => {
-            const varIndex = fnargs.indexOf(v.variable);
+            const varIndex = fnargs.indexOf(v.name);
             return constEqual(v, argtypes[varIndex]);
           })
       ];
@@ -221,7 +221,7 @@ function infer(
         },
         constraints: constraints.concat(newConstraints),
         // assumptions have already been used, so they can be deleted.
-        assumptions: assumptions.filter(v => !fnargs.includes(v.variable))
+        assumptions: assumptions.filter(v => !fnargs.includes(v.name))
       };
     }
     case "function-call": {
@@ -299,13 +299,11 @@ function infer(
           // the generalized polytype of the value to be bound.
           ...bodyInference.assumptions
             // Consider variables to be bound
-            .filter(v => toBeBound(v.variable))
+            .filter(v => toBeBound(v.name))
             .map(v => {
               // We just filter the assumptions to the variables
               // that are bound, so we know it must is defined.
-              const bInfo = bindingsInfo.find(
-                bi => bi.binding.var === v.variable
-              )!;
+              const bInfo = bindingsInfo.find(bi => bi.binding.var === v.name)!;
               return constImplicitInstance(
                 v,
                 monovars,
@@ -314,7 +312,7 @@ function infer(
             })
         ],
         assumptions: [
-          ...bodyInference.assumptions.filter(v => !toBeBound(v.variable)),
+          ...bodyInference.assumptions.filter(v => !toBeBound(v.name)),
           ...flatten(bindingsInfo.map(bi => bi.inference.assumptions))
         ]
       };
@@ -374,7 +372,7 @@ function assumptionsToConstraints(
   return flatten(
     Object.keys(typeEnvironment).map(v =>
       assumptions
-        .filter(aVar => aVar.variable === v)
+        .filter(aVar => aVar.name === v)
         .map(aVar => constExplicitInstance(aVar, typeEnvironment[v]))
     )
   );
@@ -635,8 +633,8 @@ function groupAssumptions(
   externals: TAssumption[];
   unknowns: TAssumption[];
 } {
-  const internals = assumptions.filter(v => v.variable in internalEnv);
-  const externals = assumptions.filter(v => v.variable in externalEnv);
+  const internals = assumptions.filter(v => v.name in internalEnv);
+  const externals = assumptions.filter(v => v.name in externalEnv);
   return {
     internals,
     externals,
@@ -676,7 +674,7 @@ export function inferModule(
     ...assumptionsToConstraints(assumptions.externals, externalEnv),
 
     ...assumptions.internals.map(v =>
-      constImplicitInstance(v, [], internalEnv[v.variable])
+      constImplicitInstance(v, [], internalEnv[v.name])
     )
   ];
 

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -56,10 +56,10 @@ type TConstraint =
 interface TConstraintEqual {
   type: "equal-constraint";
   t1: Monotype;
-  t2: Monotype;
+  t: Monotype;
 }
-function constEqual(t1: Monotype, t2: Monotype): TConstraintEqual {
-  return { type: "equal-constraint", t1, t2 };
+function constEqual(t1: Monotype, t: Monotype): TConstraintEqual {
+  return { type: "equal-constraint", t1, t };
 }
 
 // A constriant stating and t1 is an instance of the (poly)type t2.
@@ -241,7 +241,7 @@ function infer(
           info: { type: tTo }
         },
         constraints: ([
-          { type: "equal-constraint", t1: ifn.expr.info.type, t2: tfn }
+          constEqual(ifn.expr.info.type, tfn)
         ] as TConstraint[]).concat(
           ...ifn.constraints,
           ...iargs.map(a => a.constraints)
@@ -387,7 +387,7 @@ function activevars(constraints: TConstraint[]): string[] {
     constraints.map(c => {
       switch (c.type) {
         case "equal-constraint":
-          return union(listTypeVariables(c.t1), listTypeVariables(c.t2));
+          return union(listTypeVariables(c.t1), listTypeVariables(c.t));
         case "implicit-instance-constraint":
           return union(
             listTypeVariables(c.t1),
@@ -438,7 +438,7 @@ function applySubstitutionToConstraint(
       return {
         type: "equal-constraint",
         t1: applySubstitution(c.t1, s),
-        t2: applySubstitution(c.t2, s)
+        t: applySubstitution(c.t, s)
       };
     case "implicit-instance-constraint":
       return {
@@ -578,7 +578,7 @@ function solve(
 
   switch (constraint.type) {
     case "equal-constraint": {
-      const result = unifyOrError(constraint.t1, constraint.t2, solution);
+      const result = unifyOrError(constraint.t1, constraint.t, solution);
       const s = result.substitution;
       return solve(rest.map(c => applySubstitutionToConstraint(c, s)), s);
     }

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -25,7 +25,7 @@ import {
   listTypeVariables
 } from "./type-utils";
 import { Monotype, TVar, Type } from "./types";
-import { unify } from "./unify";
+import { unifyOrError } from "./unify";
 import { difference, flatten, intersection, mapObject, union } from "./utils";
 
 import { getInlinePrimitiveTypes } from "./compiler/inline-primitives";
@@ -578,7 +578,8 @@ function solve(
 
   switch (constraint.type) {
     case "equal-constraint": {
-      const s = unify(constraint.t1, constraint.t2, solution);
+      const result = unifyOrError(constraint.t1, constraint.t2, solution);
+      const s = result.substitution;
       return solve(rest.map(c => applySubstitutionToConstraint(c, s)), s);
     }
     case "explicit-instance-constraint": {

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -36,7 +36,7 @@ function print(sexpr: Syntax): Doc {
     case "number":
       return text(String(sexpr.value));
     case "variable-reference":
-      return printVariable(sexpr.variable);
+      return printVariable(sexpr.name);
     case "conditional":
       return group(
         list(

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -23,7 +23,7 @@ export interface SString<I = {}> extends Node<I> {
 
 export interface SVariableReference<I = {}> extends Node<I> {
   type: "variable-reference";
-  variable: SVar;
+  name: SVar;
 }
 
 export interface SConditional<I = {}> extends Node<I> {

--- a/packages/delisp-core/src/unify.ts
+++ b/packages/delisp-core/src/unify.ts
@@ -106,13 +106,11 @@ export function unify(
   } else if (t2.type === "type-variable") {
     return unifyVariable(t2, t1, ctx);
   } else {
-    throw new Error(`Couldnt unify
-${printType(t1)}
-
-with
-
-${printType(t2)}
-`);
+    return {
+      type: "unify-mismatch-error",
+      t1,
+      t2
+    };
   }
 }
 

--- a/packages/delisp-core/src/unify.ts
+++ b/packages/delisp-core/src/unify.ts
@@ -2,72 +2,128 @@ import { Substitution } from "./type-substitution";
 import { printType } from "./type-utils";
 import { Monotype, TVar } from "./types";
 
-function occurCheck(v: TVar, rootT: Monotype) {
+interface UnifySuccess {
+  type: "unify-success";
+  substitution: Substitution;
+}
+
+interface UnifyOccurCheckError {
+  type: "unify-occur-check-error";
+  variable: TVar;
+  t: Monotype;
+}
+
+interface UnifyMismatchError {
+  type: "unify-mismatch-error";
+  t1: Monotype;
+  t2: Monotype;
+}
+
+type UnifyError = UnifyOccurCheckError | UnifyMismatchError;
+type UnifyResult = UnifySuccess | UnifyError;
+
+function success(s: Substitution): UnifyResult {
+  return {
+    type: "unify-success",
+    substitution: s
+  };
+}
+
+function occurCheck(v: TVar, rootT: Monotype): UnifyError | null {
   function check(t: Monotype) {
     if (t.type === "type-variable" && t.name === v.name) {
-      throw new Error(
-        `The variable '${v.name}' cannot be part of ${printType(rootT)}`
-      );
+      const err: UnifyOccurCheckError = {
+        type: "unify-occur-check-error",
+        variable: v,
+        t: rootT
+      };
+      return err;
     }
     if (t.type === "application") {
       t.args.forEach(check);
     }
-    return;
+    return null;
   }
-
   return check(rootT);
 }
 
-function unifyVariable(v: TVar, t: Monotype, env: Substitution): Substitution {
-  if (v.name in env) {
-    return unify(env[v.name], t, env);
+function unifyVariable(v: TVar, t: Monotype, ctx: Substitution): UnifyResult {
+  if (v.name in ctx) {
+    return unify(ctx[v.name], t, ctx);
   }
   if (t.type === "type-variable") {
     if (v.name === t.name) {
-      return env;
-    } else if (t.name in env) {
-      return unifyVariable(v, env[t.name], env);
+      return success(ctx);
+    } else if (t.name in ctx) {
+      return unifyVariable(v, ctx[t.name], ctx);
     } else {
-      return { ...env, [v.name]: t };
+      return success({ ...ctx, [v.name]: t });
     }
   } else {
-    occurCheck(v, t);
-    return { ...env, [v.name]: t };
+    const err = occurCheck(v, t);
+    if (err) {
+      return err;
+    } else {
+      return success({ ...ctx, [v.name]: t });
+    }
   }
 }
 
 function unifyArray(
   t1s: Monotype[],
   t2s: Monotype[],
-  env: Substitution
-): Substitution {
+  ctx: Substitution
+): UnifyResult {
   if (t1s.length === 0 && t2s.length === 0) {
-    return env;
+    return success(ctx);
   } else {
     const [t1, ...rest1] = t1s;
     const [t2, ...rest2] = t2s;
-    const s = unify(t1, t2, env);
-    return unifyArray(rest1, rest2, s);
+    const result = unify(t1, t2, ctx);
+    if (result.type === "unify-success") {
+      return unifyArray(rest1, rest2, result.substitution);
+    } else {
+      return result;
+    }
   }
 }
 
 export function unify(
   t1: Monotype,
   t2: Monotype,
-  env: Substitution = {}
-): Substitution {
+  ctx: Substitution = {}
+): UnifyResult {
   if (t1.type === "string" && t2.type === "string") {
-    return env;
+    return success(ctx);
   } else if (t1.type === "number" && t2.type === "number") {
-    return env;
+    return success(ctx);
   } else if (t1.type === "boolean" && t2.type === "boolean") {
-    return env;
+    return success(ctx);
   } else if (t1.type === "application" && t2.type === "application") {
-    return unifyArray(t1.args, t2.args, env);
+    return unifyArray(t1.args, t2.args, ctx);
   } else if (t1.type === "type-variable") {
-    return unifyVariable(t1, t2, env);
+    return unifyVariable(t1, t2, ctx);
   } else if (t2.type === "type-variable") {
-    return unifyVariable(t2, t1, env);
+    return unifyVariable(t2, t1, ctx);
+  } else {
+    throw new Error(`Couldnt unify
+${printType(t1)}
+
+with
+
+${printType(t2)}
+`);
+  }
+}
+
+export function unifyOrError(
+  t1: Monotype,
+  t2: Monotype,
+  ctx: Substitution = {}
+): UnifySuccess {
+  const result = unify(t1, t2, ctx);
+  if (result.type === "unify-success") {
+    return result;
   } else {
     throw new Error(`Couldnt unify
 ${printType(t1)}

--- a/packages/delisp-core/src/utils.ts
+++ b/packages/delisp-core/src/utils.ts
@@ -1,3 +1,7 @@
+export function flatMap<A, B>(fn: (x: A) => B[], list: A[]): B[] {
+  return flatten(list.map(x => fn(x)));
+}
+
 export function flatten<A>(x: A[][]): A[] {
   return ([] as A[]).concat(...x);
 }

--- a/packages/delisp/src/repl.ts
+++ b/packages/delisp/src/repl.ts
@@ -56,9 +56,11 @@ const delispEval = (
   try {
     const result = inferModule(m);
     typedModule = result.typedModule;
-    result.unknowns.forEach(([name, type]) => {
+    result.unknowns.forEach(v => {
       console.warn(
-        `Unknown variable ${name} expected with type ${printType(type)}`
+        `Unknown variable ${v.variable} expected with type ${printType(
+          v.info.type
+        )}`
       );
     });
   } catch (err) {

--- a/packages/delisp/src/repl.ts
+++ b/packages/delisp/src/repl.ts
@@ -58,7 +58,7 @@ const delispEval = (
     typedModule = result.typedModule;
     result.unknowns.forEach(v => {
       console.warn(
-        `Unknown variable ${v.variable} expected with type ${printType(
+        `Unknown variable ${v.name} expected with type ${printType(
           v.info.type
         )}`
       );


### PR DESCRIPTION
This pull request aims to improve the reporting of type errors, but even more, improve the infrastructure to improve them more in the future.

The changes consist mainly of:

- [X] Improving the unification module to return information about why unification failed.

- [X] Replacing constraints between types to constraints from typed expressions and types. Doing so, the constraint solver will have access to the original expression, and its location in the source code.

- [x] Improve the solver to report errors in a bit more user-friendly way

In future PRs, error reporting can be improved further, by it requires a bit of research.

- The solver can use some heuristics to decide in which order to solve the constraints.
- All errors can be collected, not just the first one.
- Error cascading can be avoided.

We can look at how Elm does its excellent error reporting.