### PR TITLE
Use bracket notation for vectors

### DIFF
--- a/packages/delisp-core/src/compiler/inline-primitives.ts
+++ b/packages/delisp-core/src/compiler/inline-primitives.ts
@@ -143,43 +143,31 @@ defineInlinePrimitive("*", "(-> number number number)", args => {
   };
 });
 
-defineInlinePrimitive(
-  "map",
-  "(-> (-> a b) (vector a) (vector b))",
-  ([fn, vec]) => {
-    return methodCall(vec, "map", [fn]);
-  }
-);
+defineInlinePrimitive("map", "(-> (-> a b) [a] [b])", ([fn, vec]) => {
+  return methodCall(vec, "map", [fn]);
+});
 
 defineInlinePrimitive(
   "filter",
-  "(-> (-> a boolean) (vector a) (vector a))",
+  "(-> (-> a boolean) [a] [a])",
   ([predicate, vec]) => {
     return methodCall(vec, "filter", [predicate]);
   }
 );
 
-defineInlinePrimitive(
-  "fold",
-  "(-> (-> b a b) (vector a) b b)",
-  ([fn, vec, init]) => {
-    return methodCall(vec, "reduce", [fn, init]);
-  }
-);
+defineInlinePrimitive("fold", "(-> (-> b a b) [a] b b)", ([fn, vec, init]) => {
+  return methodCall(vec, "reduce", [fn, init]);
+});
 
-defineInlinePrimitive(
-  "append",
-  "(-> (vector a) (vector a) (vector a))",
-  ([vec1, vec2]) => {
-    return methodCall(vec1, "concat", [vec2]);
-  }
-);
+defineInlinePrimitive("append", "(-> [a] [a] [a])", ([vec1, vec2]) => {
+  return methodCall(vec1, "concat", [vec2]);
+});
 
-defineInlinePrimitive("reverse", "(-> (vector a) (vector a))", ([vec]) => {
+defineInlinePrimitive("reverse", "(-> [a] [a])", ([vec]) => {
   return methodCall(methodCall(vec, "slice", []), "reverse", []);
 });
 
-defineInlinePrimitive("length", "(-> (vector a) number)", ([vec]) => {
+defineInlinePrimitive("length", "(-> [a] number)", ([vec]) => {
   return {
     type: "MemberExpression",
     computed: false,

--- a/packages/delisp-core/src/convert-type.ts
+++ b/packages/delisp-core/src/convert-type.ts
@@ -1,5 +1,5 @@
 import { printHighlightedExpr } from "./error-report";
-import { ASExpr, ASExprList, ASExprSymbol } from "./sexpr";
+import { ASExpr, ASExprList, ASExprSymbol, ASExprVector } from "./sexpr";
 import {
   Monotype,
   tApp,
@@ -7,6 +7,7 @@ import {
   tNumber,
   tString,
   tVar,
+  tVector,
   tVoid
 } from "./types";
 
@@ -46,13 +47,6 @@ function convertList(expr: ASExprList): Monotype {
         );
       }
       break;
-    case "vector":
-      if (args.length !== 1) {
-        throw new Error(
-          printHighlightedExpr("Expected exactly 1 argument", op.location)
-        );
-      }
-      break;
     default:
       throw new Error(
         printHighlightedExpr("Unknown type constructor", op.location)
@@ -62,12 +56,23 @@ function convertList(expr: ASExprList): Monotype {
   return tApp(op.name, ...args.map(convert));
 }
 
+function convertVector(expr: ASExprVector): Monotype {
+  if (expr.elements.length !== 1) {
+    throw new Error(
+      printHighlightedExpr("Expected exactly 1 argument", expr.location)
+    );
+  }
+  return tVector(convert(expr.elements[0]));
+}
+
 export function convert(expr: ASExpr): Monotype {
   switch (expr.type) {
     case "list":
       return convertList(expr);
     case "symbol":
       return convertSymbol(expr);
+    case "vector":
+      return convertVector(expr);
     default:
       throw new Error(printHighlightedExpr("Not a valid type", expr.location));
   }

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -119,16 +119,6 @@ defineConversion("if", expr => {
   };
 });
 
-defineConversion("vector", expr => {
-  const [, ...args] = expr.elements;
-  return {
-    type: "vector",
-    values: args.map(a => convertExpr(a)),
-    location: expr.location,
-    info: {}
-  };
-});
-
 function parseLetBindings(bindings: ASExpr): SLetBinding[] {
   if (bindings.type !== "list") {
     throw new Error(

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -30,6 +30,10 @@ function list(...docs: Doc[]): Doc {
   return concat(text("("), ...docs, text(")"));
 }
 
+function vector(...docs: Doc[]): Doc {
+  return concat(text("["), ...docs, text("]"));
+}
+
 function map(...docs: Doc[]): Doc {
   return concat(text("{"), ...docs, text("}"));
 }
@@ -41,9 +45,8 @@ function print(sexpr: Syntax): Doc {
     case "number":
       return text(String(sexpr.value));
     case "vector": {
-      const fn = text("vector");
       const args = sexpr.values.map(print);
-      return group(list(groupalign(fn, align(...args))));
+      return group(vector(align(...args)));
     }
     case "record": {
       return group(

--- a/packages/delisp-core/src/type-utils.ts
+++ b/packages/delisp-core/src/type-utils.ts
@@ -1,7 +1,7 @@
 import { convert as convertType } from "./convert-type";
 import { readFromString } from "./reader";
 import { applySubstitution } from "./type-substitution";
-import { Monotype, tVar, TVar, Type } from "./types";
+import { Monotype, TApplication, tVar, TVar, Type } from "./types";
 import { flatMap, unique } from "./utils";
 
 // Return the list of type variables in the order they show up
@@ -68,10 +68,19 @@ function normalizeType(t: Monotype): Monotype {
   return applySubstitution(t, substitution);
 }
 
+function printApplicationType(type: TApplication) {
+  switch (type.op) {
+    case "vector":
+      return `[${_printType(type.args[0])}]`;
+    default:
+      return `(${type.op} ${type.args.map(_printType).join(" ")})`;
+  }
+}
+
 function _printType(type: Monotype): string {
   switch (type.type) {
     case "application":
-      return `(${type.op} ${type.args.map(_printType).join(" ")})`;
+      return printApplicationType(type);
     case "void":
       return "void";
     case "boolean":

--- a/packages/delisp-core/src/types.ts
+++ b/packages/delisp-core/src/types.ts
@@ -17,7 +17,7 @@ interface TString {
   type: "string";
 }
 
-interface TApplication {
+export interface TApplication {
   type: "application";
   op: string;
   args: Monotype[];

--- a/packages/delisp-runtime/src/primitives.ts
+++ b/packages/delisp-runtime/src/primitives.ts
@@ -34,17 +34,17 @@ const prims: Primitives = {
   },
 
   nil: {
-    type: "(vector a)",
+    type: "[a]",
     value: []
   },
 
   cons: {
-    type: "(-> a (vector a) (vector a))",
+    type: "(-> a [a] [a])",
     value: <T>(a: T, list: T[]): T[] => [a, ...list]
   },
 
   first: {
-    type: "(-> (vector a) a)",
+    type: "(-> [a] a)",
     value: <T>(list: T[]): T => {
       if (list.length > 0) {
         return list[0];
@@ -55,7 +55,7 @@ const prims: Primitives = {
   },
 
   rest: {
-    type: "(-> (vector a) (vector a))",
+    type: "(-> [a] [a])",
     value: <T>(list: T[]): T[] => {
       if (list.length > 0) {
         const [, ...rest] = list;
@@ -67,7 +67,7 @@ const prims: Primitives = {
   },
 
   "empty?": {
-    type: "(-> (vector a) boolean)",
+    type: "(-> [a] boolean)",
     value: <T>(list: T[]): boolean => list.length === 0
   }
 };


### PR DESCRIPTION
- Add `[1 2 3]` syntax to the pretty printer (currently this was being rewritten as `(vector 1 2 3)`)
- Add `[a]` syntax for vector types (both for reading and output)