### PR TITLE
Multiform lambda

### DIFF
--- a/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
@@ -49,13 +49,13 @@ exports[`Compiler Error messages generate nice error message for invalid definit
 `;
 
 exports[`Compiler Error messages generate nice error message for invalid lambda expressions 1`] = `
-"file:1:6: 'lambda' needs exactly 2 arguments, got 0
+"file:1:6: 'lambda' is missing the body
 (lambda)
 ------^"
 `;
 
 exports[`Compiler Error messages generate nice error message for invalid lambda expressions 2`] = `
-"file:1:8: 'lambda' needs exactly 2 arguments, got 1
+"file:1:8: 'lambda' is missing the body
 (lambda 7)
 --------^"
 `;

--- a/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
@@ -187,6 +187,18 @@ exports[`Pretty Printer should print lambda abstractions beautifully 3`] = `
   xxx)"
 `;
 
+exports[`Pretty Printer should print lambda with multiple forms 1`] = `
+"
+(define hello
+  (lambda (x)
+    (print x)
+    (print x)
+    (print x)
+    (print x)
+    (print x)
+    (print x)))"
+`;
+
 exports[`Pretty Printer should print let expressions nicely 1`] = `
 "
 (let ((x 10)

--- a/packages/delisp-core/__tests__/eval.ts
+++ b/packages/delisp-core/__tests__/eval.ts
@@ -38,6 +38,10 @@ describe("Evaluation", () => {
       expect(evaluateString("((lambda (x y) y) 4 5)")).toBe(5);
     });
 
+    it("should return the last expression of the body", () => {
+      expect(evaluateString("((lambda (x) x 1) 10)")).toBe(1);
+    });
+
     // Regression
     it("different argument names should not shadow", () => {
       expect(

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -57,6 +57,10 @@ describe("Type inference", () => {
         // lambda-bound variables should be monomorphic
         expect(() => typeOf(`(lambda (f) ((f "foo") (f 0)))`)).toThrow();
       });
+
+      it("should return the type of the last form", () => {
+        expect(typeOf("(lambda (x) 1)")).toBe("(-> α number)");
+      });
     });
 
     describe("Let polymorphism", () => {

--- a/packages/delisp-core/__tests__/printer.ts
+++ b/packages/delisp-core/__tests__/printer.ts
@@ -134,4 +134,20 @@ describe("Pretty Printer", () => {
       )
     ).toMatchSnapshot();
   });
+
+  it("should print lambda with multiple forms", () => {
+    expect(
+      pprintString(
+        `
+(define hello (lambda (x)
+                (print x)
+                (print x)
+                (print x)
+                (print x)
+                (print x)
+                (print x)))
+`
+      )
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -14,7 +14,7 @@ import {
   SVectorConstructor,
   Syntax
 } from "./syntax";
-import { mapObject } from "./utils";
+import { last, mapObject } from "./utils";
 
 import {
   DefinitionBackend,
@@ -81,10 +81,29 @@ function compileLambda(
     })
   );
 
+  const body: JS.Expression | JS.Statement =
+    fn.body.length === 1
+      ? compile(fn.body[0], newEnv)
+      : {
+          type: "BlockStatement",
+          body: [
+            ...fn.body.slice(0, -1).map(
+              (e): JS.ExpressionStatement => ({
+                type: "ExpressionStatement",
+                expression: compile(e, newEnv)
+              })
+            ),
+            {
+              type: "ReturnStatement",
+              argument: compile(last(fn.body)!, newEnv)
+            }
+          ]
+        };
+
   return {
     type: "ArrowFunctionExpression",
     params: [...jsargs],
-    body: compile(fn.body, newEnv),
+    body,
     expression: false
   };
 }

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -78,20 +78,21 @@ function parseLambdaList(ll: ASExpr): LambdaList {
 defineConversion("lambda", expr => {
   const [lambda, ...args] = expr.elements;
 
-  if (args.length !== 2) {
+  if (args.length < 2) {
     const lastExpr = last([lambda, ...args]) as ASExpr; // we know it is not empty!
     throw new Error(
       printHighlightedExpr(
-        `'lambda' needs exactly 2 arguments, got ${args.length}`,
+        `'lambda' is missing the body`,
         lastExpr.location,
         true
       )
     );
   }
+
   return {
     type: "function",
     lambdaList: parseLambdaList(args[0]),
-    body: convertExpr(args[1]),
+    body: args.slice(1).map(convertExpr),
     location: expr.location,
     info: {}
   };

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -86,14 +86,14 @@ function print(sexpr: Syntax): Doc {
 
     case "function":
       const argNames = sexpr.lambdaList.positionalArgs.map(x => x.variable);
-      return group(
-        list(
-          text("lambda"),
-          space,
-          group(list(align(...argNames.map(printVariable)))),
-          indent(concat(line, join(sexpr.body.map(print), line)))
-        )
+      const singleBody = sexpr.body.length === 1;
+      const doc = list(
+        text("lambda"),
+        space,
+        group(list(align(...argNames.map(printVariable)))),
+        indent(concat(line, join(sexpr.body.map(print), line)))
       );
+      return singleBody ? group(doc) : doc;
 
     case "function-call": {
       const fn = print(sexpr.fn);

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -91,7 +91,7 @@ function print(sexpr: Syntax): Doc {
           text("lambda"),
           space,
           group(list(align(...argNames.map(printVariable)))),
-          indent(concat(line, print(sexpr.body)))
+          indent(concat(line, join(sexpr.body.map(print), line)))
         )
       );
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -47,7 +47,7 @@ export interface LambdaList {
 export interface SFunction<I = {}> extends Node<I> {
   type: "function";
   lambdaList: LambdaList;
-  body: Expression<I>;
+  body: Array<Expression<I>>;
 }
 
 export interface SVectorConstructor<I = {}> extends Node<I> {


### PR DESCRIPTION
Support for lambdas with multiple forms

```lisp
(lambda (x)
  (print x)
  (print x))
```