### PR TITLE
Type annotations

### DIFF
--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -110,5 +110,13 @@ describe("Type inference", () => {
         expect(typeOf("(if true [] [1])")).toBe("[number]");
       });
     });
+
+    describe("Type annotations", () => {
+      it("user-specified variables cannot generalize inferrred types", () => {
+        expect(() =>
+          typeOf(`(the (-> a a) (the (-> string string) (lambda (x) x)))`)
+        ).toThrow();
+      });
+    });
   });
 });

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -112,7 +112,16 @@ describe("Type inference", () => {
     });
 
     describe("Type annotations", () => {
-      it("user-specified variables cannot generalize inferrred types", () => {
+      it("user-specified variables can specialize inferred types", () => {
+        expect(typeOf("(the [number] [])")).toBe("[number]");
+      });
+
+      it("user-specified variables can be isomorphic to inferred types", () => {
+        expect(typeOf("(the [a] [])")).toBe("[α]");
+      });
+
+      it("user-specified variables cannot generalize inferred types", () => {
+        expect(() => typeOf(`(the a 3)`)).toThrow();
         expect(() =>
           typeOf(`(the (-> a a) (the (-> string string) (lambda (x) x)))`)
         ).toThrow();

--- a/packages/delisp-core/src/__snapshots__/convert-type.spec.ts.snap
+++ b/packages/delisp-core/src/__snapshots__/convert-type.spec.ts.snap
@@ -50,6 +50,7 @@ Object {
         "extends": Object {
           "name": "a",
           "type": "type-variable",
+          "userSpecified": false,
         },
         "label": "y",
         "labelType": Object {

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -299,6 +299,8 @@ export function compile(expr: Expression, env: Environment): JS.Expression {
       return compileFunctionCall(expr, env);
     case "let-bindings":
       return compileLetBindings(expr, env);
+    case "type-annotation":
+      return compile(expr.value, env);
   }
 }
 

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -393,6 +393,17 @@ function infer(
         ]
       };
     }
+
+    case "type-annotation":
+      const inferred = infer(expr.value, monovars);
+      return {
+        result: inferred.result,
+        assumptions: inferred.assumptions,
+        constraints: [
+          ...inferred.constraints,
+          constExplicitInstance(inferred.result, expr.valueType)
+        ]
+      };
   }
 }
 
@@ -614,6 +625,15 @@ function applySubstitutionToExpr(
           value: applySubstitutionToExpr(b.value, env)
         })),
         body: s.body.map(e => applySubstitutionToExpr(e, env)),
+        info: {
+          ...s.info,
+          type: applySubstitution(s.info.type, env)
+        }
+      };
+    case "type-annotation":
+      return {
+        ...s,
+        value: applySubstitutionToExpr(s.value, env),
         info: {
           ...s.info,
           type: applySubstitution(s.info.type, env)

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -13,6 +13,8 @@ import {
 } from "./prettier";
 import { Module, Syntax } from "./syntax";
 
+import { printType } from "./type-utils";
+
 function indent(x: Doc, level = 2): Doc {
   return indent_(x, level);
 }
@@ -135,6 +137,16 @@ function print(sexpr: Syntax): Doc {
           )
         ),
         indent(printBody(sexpr.body))
+      );
+
+    case "type-annotation":
+      return group(
+        list(
+          text("the"),
+          space,
+          text(printType(sexpr.valueType.mono, false)),
+          indent(concat(line, print(sexpr.value)))
+        )
       );
   }
 }

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -1,4 +1,5 @@
 import { Location } from "./input";
+import { Type } from "./types";
 
 //
 // Expressions
@@ -76,6 +77,12 @@ export interface SRecord<I = {}> extends Node<I> {
   }>;
 }
 
+export interface STypeAnnotation<I = {}> extends Node<I> {
+  type: "type-annotation";
+  value: Expression<I>;
+  valueType: Type;
+}
+
 export type Expression<I = {}> =
   | SNumber<I>
   | SString<I>
@@ -85,7 +92,8 @@ export type Expression<I = {}> =
   | SFunction<I>
   | SVectorConstructor<I>
   | SLet<I>
-  | SRecord<I>;
+  | SRecord<I>
+  | STypeAnnotation<I>;
 
 //
 // Declarations

--- a/packages/delisp-core/src/type-utils.ts
+++ b/packages/delisp-core/src/type-utils.ts
@@ -139,8 +139,8 @@ function _printType(type: Monotype): string {
   }
 }
 
-export function printType(rawType: Monotype) {
-  const type = normalizeType(rawType);
+export function printType(rawType: Monotype, normalize = true) {
+  const type = normalize ? normalizeType(rawType) : rawType;
   return _printType(type);
 }
 

--- a/packages/delisp-core/src/type-utils.ts
+++ b/packages/delisp-core/src/type-utils.ts
@@ -26,8 +26,8 @@ export function listTypeVariables(t: Monotype): string[] {
 }
 
 let generateUniqueTVarIdx = 0;
-export const generateUniqueTVar = (): TVar =>
-  tVar(`t${++generateUniqueTVarIdx}`);
+export const generateUniqueTVar = (userSpecified = false): TVar =>
+  tVar(`t${++generateUniqueTVarIdx}`, userSpecified);
 
 export function generalize(t: Monotype, monovars: string[]): Type {
   const vars = listTypeVariables(t);
@@ -41,11 +41,11 @@ export function generalize(t: Monotype, monovars: string[]): Type {
   };
 }
 
-export function instantiate(t: Type): Monotype {
+export function instantiate(t: Type, userSpecified = false): Monotype {
   const subst = t.tvars.reduce((s, vname) => {
     return {
       ...s,
-      [vname]: generateUniqueTVar()
+      [vname]: generateUniqueTVar(userSpecified)
     };
   }, {});
   return applySubstitution(t.mono, subst);

--- a/packages/delisp-core/src/types.ts
+++ b/packages/delisp-core/src/types.ts
@@ -26,6 +26,7 @@ export interface TApplication {
 export interface TVar {
   type: "type-variable";
   name: string;
+  userSpecified: boolean;
 }
 
 export interface REmpty {
@@ -77,10 +78,11 @@ export const tString: TString = {
   type: "string"
 };
 
-export function tVar(name: string): TVar {
+export function tVar(name: string, userSpecified = false): TVar {
   return {
     type: "type-variable",
-    name
+    name,
+    userSpecified
   };
 }
 

--- a/packages/delisp-core/src/unify.ts
+++ b/packages/delisp-core/src/unify.ts
@@ -211,13 +211,26 @@ export function unify(
     return success(ctx);
   } else if (t1.type === "boolean" && t2.type === "boolean") {
     return success(ctx);
+  } else if (
+    t1.type === "type-variable" &&
+    t1.userSpecified &&
+    t2.type === "type-variable" &&
+    t2.userSpecified
+  ) {
+    return t1 === t2
+      ? success(ctx)
+      : {
+          type: "unify-mismatch-error",
+          t1,
+          t2
+        };
   } else if (t1.type === "application" && t2.type === "application") {
     // RULE: (uni-app)
     return unifyArray(t1.args, t2.args, ctx);
-  } else if (t1.type === "type-variable") {
+  } else if (t1.type === "type-variable" && !t1.userSpecified) {
     // RULE: (uni-varl)
     return unifyVariable(t1, t2, ctx);
-  } else if (t2.type === "type-variable") {
+  } else if (t2.type === "type-variable" && !t2.userSpecified) {
     // RULE: (uni-varr)
     return unifyVariable(t2, t1, ctx);
   } else if (t1.type === "empty-row" && t2.type === "empty-row") {


### PR DESCRIPTION
Introduce type annotations with the syntax

```scheme
(the TYPE EXPR)
```

During type inference, this form will introduce an explicit constraint.  However, note that we do not want to allow user-provided type annotations to generalize inferred types.

For instance, the second form in here should fail:

```scheme
(define string-id
  (the (-> string string)
    (lambda (x) x)))

(the (-> a a) string-id)  ??
```

This is solved by introducing `rigid/user-specified type variables`.  Those variables *unify only with themselves* (and normal variables),  but not with constants.

e.g:  `unify(rigid a, string) fails`

That avoids the undesired behaviour above.