### PR TITLE
WIP: Add comments with type for exports

### DIFF
--- a/packages/delisp/src/index.ts
+++ b/packages/delisp/src/index.ts
@@ -49,7 +49,7 @@ export async function compileFile(file: string): Promise<void> {
     throw new Error(unknowns.join("\n\n"));
   }
 
-  const code = compileModuleToString(module);
+  const code = compileModuleToString(inferResult.typedModule);
 
   await mkdirp(path.dirname(outfile));
   await fs.writeFile(outfile, code);


### PR DESCRIPTION
Just a little experiment, but it would be nice to be able to enable something like this in the output.

- Pass the `TypedModule` (from `infer`) to `compile`, so type info becomes accessible
- Using `(exp.value.info as any).type` to get the type of an expression, because we do not have an explicit `Node<Untyped>` yet.
- The `estree` types are not fully compatible with `recast`, in particular the comments work differently. Where `estree` expects `leadingComments: []` and `trailingComments: []` on the `Expression` itself, `recast` uses a `comments: []` fields and checks for a `leading` or `trailing` flag inside the `Comment` (so some `as JS.ExpressionStatement` hacks were needed).


Result is that

```lisp
(export foo 42)
```

compiles to

```js
// type: number
module.exports.foo = 42;
```
