### PR TITLE
Fix error when application arity does not match

### DIFF
--- a/packages/delisp-core/__tests__/unify.ts
+++ b/packages/delisp-core/__tests__/unify.ts
@@ -13,7 +13,7 @@ describe("Unification", () => {
     const t1 = tFn([tNumber, tNumber], tNumber);
     const t2 = tFn([tNumber], tNumber);
     const result = unify(t1, t2);
-    expect(result.type).not.toBe("unify-syccess");
+    expect(result.type).toBe("unify-missing-value-error");
   });
 
   describe("Records", () => {

--- a/packages/delisp-core/__tests__/unify.ts
+++ b/packages/delisp-core/__tests__/unify.ts
@@ -9,11 +9,19 @@ describe("Unification", () => {
     expect(result.type).toBe("unify-occur-check-error");
   });
 
-  it("should catch function arity mismatches", () => {
-    const t1 = tFn([tNumber, tNumber], tNumber);
-    const t2 = tFn([tNumber], tNumber);
-    const result = unify(t1, t2);
-    expect(result.type).toBe("unify-missing-value-error");
+  describe("Application", () => {
+    it("should catch function arity mismatches", () => {
+      const t1 = tFn([tNumber, tNumber], tNumber);
+      const t2 = tFn([tNumber], tNumber);
+      const result = unify(t1, t2);
+      expect(result.type).toBe("unify-missing-value-error");
+    });
+    it("should catch operator mismatches", () => {
+      const t1 = tVector(tNumber);
+      const t2 = tFn([], tNumber);
+      const result = unify(t1, t2);
+      expect(result.type).toBe("unify-mismatch-error");
+    });
   });
 
   describe("Records", () => {

--- a/packages/delisp-core/__tests__/unify.ts
+++ b/packages/delisp-core/__tests__/unify.ts
@@ -1,4 +1,4 @@
-import { tNumber, tVar, tVector, tRecord } from "../src/types";
+import { tFn, tNumber, tRecord, tVar, tVector } from "../src/types";
 import { unify } from "../src/unify";
 
 describe("Unification", () => {
@@ -7,6 +7,13 @@ describe("Unification", () => {
     const t2 = tVector(t1);
     const result = unify(t1, t2);
     expect(result.type).toBe("unify-occur-check-error");
+  });
+
+  it("should catch function arity mismatches", () => {
+    const t1 = tFn([tNumber, tNumber], tNumber);
+    const t2 = tFn([tNumber], tNumber);
+    const result = unify(t1, t2);
+    expect(result.type).not.toBe("unify-syccess");
   });
 
   describe("Records", () => {

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -734,7 +734,23 @@ ${printType(applySubstitution(constraint.expr.info.type, solution))}
 
 vs.
 
+${printType(applySubstitution(constraint.t, solution))}`,
+              constraint.expr.location
+            )
+          );
+        case "unify-missing-value-error":
+          throw new Error(
+            printHighlightedExpr(
+              `Type mismatch
+
+Missing value of type ${printType(applySubstitution(result.t, solution))}
+
+${printType(applySubstitution(constraint.expr.info.type, solution))}
+
+vs.
+
 ${printType(applySubstitution(constraint.t, solution))}
+
 `,
               constraint.expr.location
             )

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -726,6 +726,10 @@ function solve(
             printHighlightedExpr(
               `Type mismatch
 
+Expected ${printType(
+                applySubstitution(result.t2, solution)
+              )} instead of ${printType(applySubstitution(result.t1, solution))}
+
 ${printType(applySubstitution(constraint.expr.info.type, solution))}
 
 vs.

--- a/packages/delisp-core/src/unify.ts
+++ b/packages/delisp-core/src/unify.ts
@@ -14,7 +14,7 @@
 
 import { Substitution } from "./type-substitution";
 import { generateUniqueTVar } from "./type-utils";
-import { Monotype, RExtension, tRowExtension, TVar } from "./types";
+import { Monotype, RExtension, tRowExtension, TVar, tVoid } from "./types";
 
 interface UnifySuccess {
   type: "unify-success";
@@ -205,7 +205,11 @@ export function unify(
   ctx: Substitution = {}
 ): UnifyResult {
   // RULE (uni-const)
-  if (t1.type === "string" && t2.type === "string") {
+  if (t1 === undefined) {
+    return { type: "unify-mismatch-error", t1: tVoid, t2 };
+  } else if (t2 === undefined) {
+    return { type: "unify-mismatch-error", t1, t2: tVoid };
+  } else if (t1.type === "string" && t2.type === "string") {
     return success(ctx);
   } else if (t1.type === "number" && t2.type === "number") {
     return success(ctx);

--- a/packages/delisp-core/src/unify.ts
+++ b/packages/delisp-core/src/unify.ts
@@ -243,7 +243,11 @@ export function unify(
           t1,
           t2
         };
-  } else if (t1.type === "application" && t2.type === "application") {
+  } else if (
+    t1.type === "application" &&
+    t2.type === "application" &&
+    t1.op === t2.op
+  ) {
     // RULE: (uni-app)
     const argResult = unifyArray(
       t1.args.slice(0, t1.args.length - 1),


### PR DESCRIPTION
This currently breaks the unification process:

```lisp
(+ 1)
```

Result: `TypeError: Cannot read property 'type' of undefined` (when trying to unify `b`).

- Minimal change needed is to explicitly check if `t1` or `t2` are `undefined`, and report it as a `unify-mismatch-error` (with `void`). This prevents the compiler from crashing completely.
- To improve, I added a `unity-missing-value-error` to differentiate between actual mismatches with `void`, for example in `(+ 1 (print "hi")`)
- Updated unification of `application` a bit to first unify the input arguments, then unify the return value separately. This improves error messages and is needed to handle multiple return values properly in the future.