### PR TITLE
Update printer to preserve empty lines

### DIFF
--- a/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
@@ -85,6 +85,13 @@ exports[`Pretty Printer should align nested function calls 3`] = `
                ttt))"
 `;
 
+exports[`Pretty Printer should insert newlines 1`] = `
+"
+aaa
+bbb
+ccc"
+`;
+
 exports[`Pretty Printer should place all arguments of a function call in the next line if necessary 1`] = `
 "
 (this-is-a-very-long-and-ugly-function-name
@@ -93,6 +100,17 @@ exports[`Pretty Printer should place all arguments of a function call in the nex
           (a b c d)
           (a b c d)
           (a b c d)))"
+`;
+
+exports[`Pretty Printer should preserve some empty lines 1`] = `
+"
+aaa
+bbb
+
+ccc
+ddd
+
+eee"
 `;
 
 exports[`Pretty Printer should pretty print a combination of lambda and function call 1`] = `

--- a/packages/delisp-core/__tests__/printer.ts
+++ b/packages/delisp-core/__tests__/printer.ts
@@ -1,12 +1,35 @@
-import { readSyntax } from "../src/index";
-import { pprint } from "../src/printer";
+import { readModule, readSyntax } from "../src/index";
+import { pprint, pprintModule } from "../src/printer";
 
 function pprintString(source: string, lineWidth: number = 80) {
   const syntax = readSyntax(source);
   return "\n" + pprint(syntax, lineWidth);
 }
 
+function pprintLines(source: string, lineWidth: number = 80) {
+  const m = readModule(source);
+  return "\n" + pprintModule(m, lineWidth);
+}
+
 describe("Pretty Printer", () => {
+  it("should insert newlines", () => {
+    expect(pprintLines(`aaa bbb ccc`)).toMatchSnapshot();
+  });
+  it("should preserve some empty lines", () => {
+    expect(
+      pprintLines(`
+aaa
+bbb
+
+ccc
+ddd
+
+
+eee
+`)
+    ).toMatchSnapshot();
+  });
+
   it("should print lambda abstractions beautifully", () => {
     expect(pprintString("(lambda (aaa bbb ccc) xxx)")).toMatchSnapshot();
     expect(

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -156,5 +156,19 @@ export function pprint(sexpr: Syntax, lineWidth: number): string {
 }
 
 export function pprintModule(m: Module, lineWidth: number): string {
-  return m.body.map(s => pprint(s, lineWidth)).join("\n\n");
+  return m.body
+    .map((s, i) => {
+      let newlines;
+      if (i > 0) {
+        const end = m.body[i - 1].location.end;
+        const start = s.location.start;
+        const between = s.location.input.toString().slice(end, start);
+        newlines = between.split("\n").length - 1;
+      } else {
+        newlines = 0;
+      }
+      const nl = newlines > 1 ? "\n" : "";
+      return nl + pprint(s, lineWidth);
+    })
+    .join("\n");
 }


### PR DESCRIPTION
Bit of a crude implementation, but it checks if there was more than 1 `\n` character in between expressions, and adds a single empty line in the output. This allows grouping of lines (while disallowing multiple empty lines in succession): 

```
(define foo 1)
(define bar 2)

(define baz 3)
```