### PR TITLE
ESM exports

### DIFF
--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -137,9 +137,9 @@ function compileExport(exp: SExport, env: Environment): JS.Statement {
           object: { type: "Identifier", name: "module" },
           property: { type: "Identifier", name: "exports" }
         },
-        exp.name
+        exp.value.name
       ),
-      right: compile(exp.value, env)
+      right: compileVariable(exp.value, env)
     }
   };
 }

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -349,7 +349,10 @@ function compileRuntime(): JS.VariableDeclaration {
   };
 }
 
-function compileExports(exps: SExport[], env: Environment) {
+function compileExports(
+  exps: SExport[],
+  env: Environment
+): Array<JS.Statement | JS.ModuleDeclaration> {
   const exportNames = exps.map(exp => {
     const binding = lookupBinding(exp.value.name, env);
     if (!binding || binding.source !== "module") {
@@ -364,7 +367,11 @@ function compileExports(exps: SExport[], env: Environment) {
     }
   });
 
-  return env.moduleFormat.export(exportNames);
+  if (exportNames.length > 0) {
+    return [env.moduleFormat.export(exportNames)];
+  } else {
+    return [];
+  }
 }
 
 export function moduleEnvironment(
@@ -413,7 +420,7 @@ function compileModule(
     body: [
       ...(includeRuntime ? [compileRuntime()] : []),
       ...maybeMap((syntax: Syntax) => compileTopLevel(syntax, env), m.body),
-      compileExports(m.body.filter(isExport), env)
+      ...compileExports(m.body.filter(isExport), env)
     ]
   };
 }

--- a/packages/delisp-core/src/compiler/modules.ts
+++ b/packages/delisp-core/src/compiler/modules.ts
@@ -1,0 +1,61 @@
+import * as JS from "estree";
+import { member } from "./estree-utils";
+import { identifierToJS } from "./jsvariable";
+
+import { printHighlightedExpr } from "../error-report";
+import { SExport } from "../syntax";
+
+export interface ModuleBackend {
+  export(
+    name: string,
+    value: JS.Expression,
+    exp: SExport
+  ): JS.Statement | JS.ModuleDeclaration;
+}
+
+export const cjs: ModuleBackend = {
+  export(name, value) {
+    return {
+      type: "ExpressionStatement",
+      expression: {
+        type: "AssignmentExpression",
+        operator: "=",
+        left: member(
+          {
+            type: "MemberExpression",
+            computed: false,
+            object: { type: "Identifier", name: "module" },
+            property: { type: "Identifier", name: "exports" }
+          },
+          identifierToJS(name)
+        ),
+        right: value
+      }
+    };
+  }
+};
+
+export const esm: ModuleBackend = {
+  export(name, value, exp) {
+    if (value.type !== "Identifier") {
+      throw new Error(
+        printHighlightedExpr(
+          "Only user defined symbols can be exported",
+          exp.value.location
+        )
+      );
+    }
+    return {
+      type: "ExportNamedDeclaration",
+      exportKind: "value",
+      specifiers: [
+        {
+          type: "ExportSpecifier",
+          local: value,
+          exported: { type: "Identifier", name: identifierToJS(name) }
+        }
+      ],
+      declaration: null
+    };
+  }
+};

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -122,7 +122,7 @@ function print(sexpr: Syntax): Doc {
         list(
           text("export"),
           space,
-          text(sexpr.name),
+          text(sexpr.value.name),
           indent(concat(line, print(sexpr.value)))
         )
       );

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -128,6 +128,10 @@ export function isDefinition(syntax: Syntax): syntax is SDefinition {
   return syntax.type === "definition";
 }
 
+export function isExport(syntax: Syntax): syntax is SExport {
+  return syntax.type === "export";
+}
+
 export interface Module<I = {}> {
   type: "module";
   body: Array<Syntax<I>>;

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -109,8 +109,7 @@ export interface SDefinition<I = {}> {
 
 export interface SExport<I = {}> {
   type: "export";
-  name: string;
-  value: Expression<I>;
+  value: SVariableReference<I>;
   location: Location;
 }
 


### PR DESCRIPTION
- Updated export syntax from `(export name val)` to `(export sym)`
- Added a `moduleFormat` to the compiler `Env`
   - Moved the old compileExport code to a `cjs` ModuleBackend
   - Created a `esm` ModuleBackend
- To use the esm backend, run `ESM=1 delisp compile file.dl`