### PR TITLE
Implement type aliases

### DIFF
--- a/editor/emacs/delisp.el
+++ b/editor/emacs/delisp.el
@@ -154,6 +154,11 @@
    (list "(\\\(define\\\)\\(?:\\s-+\\\(\\sw+\\\)\\)?"
          '(1 font-lock-keyword-face nil)
          '(2 font-lock-variable-name-face))
+
+   (list "(\\\(type\\\)\\(?:\\s-+\\\(\\sw+\\\)\\)?"
+         '(1 font-lock-keyword-face nil)
+         '(2 font-lock-variable-name-face))
+
    (list
     (concat "(" (regexp-opt '("if" "lambda" "let" "export" "and" "or" "the") t) "\\>")
     '(1 font-lock-keyword-face))

--- a/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Compiler Error messages generate nice error message for bad type declarations 1`] = `
+"file:1:5: 'type' needs exactly 2 arguments, got 0
+(type)
+----^"
+`;
+
+exports[`Compiler Error messages generate nice error message for bad type declarations 2`] = `
+"file:1:7: 'type' needs exactly 2 arguments, got 1
+(type a)
+------^"
+`;
+
+exports[`Compiler Error messages generate nice error message for bad type declarations 3`] = `
+"file:1:7: 'type' needs exactly 2 arguments, got 1
+(type A)
+------^"
+`;
+
+exports[`Compiler Error messages generate nice error message for bad type declarations 4`] = `
+"file:1:9: Not a valid type
+(type A 3)
+--------^"
+`;
+
+exports[`Compiler Error messages generate nice error message for bad type declarations 5`] = `
+"file:1:7: 'a' is not a valid name for a type. Type names should start with a capital letter. Try 'A'?
+(type a {})
+------^"
+`;
+
 exports[`Compiler Error messages generate nice error message for conditionals 1`] = `
 "file:1:3: 'if' needs exactly 3 arguments, got 1
 (if)

--- a/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Compiler Error messages generate a nice error for some basic invalid syntax 1`] = `
+"file:1:1: Empty list is not a function call
+()
+^"
+`;
+
 exports[`Compiler Error messages generate nice error message for bad type declarations 1`] = `
 "file:1:5: 'type' needs exactly 2 arguments, got 0
 (type)
@@ -28,6 +34,24 @@ exports[`Compiler Error messages generate nice error message for bad type declar
 "file:1:7: 'a' is not a valid name for a type. Type names should start with a capital letter. Try 'A'?
 (type a {})
 ------^"
+`;
+
+exports[`Compiler Error messages generate nice error message for bad type declarations 6`] = `
+"file:1:14: 'type' needs exactly 2 arguments, got 3
+(type ID {} 10)
+-------------^"
+`;
+
+exports[`Compiler Error messages generate nice error message for bad type declarations 7`] = `
+"file:1:7: 'type' expected a symbol as a name
+(type 3 5)
+------^"
+`;
+
+exports[`Compiler Error messages generate nice error message for bad type declarations 8`] = `
+"file:1:10: Type variable out of scope
+(type ID (-> a a))
+---------^"
 `;
 
 exports[`Compiler Error messages generate nice error message for conditionals 1`] = `
@@ -78,6 +102,12 @@ exports[`Compiler Error messages generate nice error message for invalid definit
 --------^"
 `;
 
+exports[`Compiler Error messages generate nice error message for invalid definitions 5`] = `
+"file:1:15: 'define' needs exactly 2 arguments, got 3
+(define x 10 23)
+--------------^"
+`;
+
 exports[`Compiler Error messages generate nice error message for invalid lambda expressions 1`] = `
 "file:1:7: 'lambda' is missing the argument list
 (lambda)
@@ -105,6 +135,12 @@ exports[`Compiler Error messages generate nice error message for invalid lambda 
 exports[`Compiler Error messages generate nice error message for invalid lambda expressions 5`] = `
 "file:1:12: A list of arguments should be made of symbols
 (lambda (x 7) x)
+-----------^"
+`;
+
+exports[`Compiler Error messages generate nice error message for invalid lambda expressions 6`] = `
+"file:1:12: There is another argument with the same name
+(lambda (x x) x)
 -----------^"
 `;
 
@@ -144,8 +180,62 @@ exports[`Compiler Error messages generate nice error message for invalid records
 -------^"
 `;
 
+exports[`Compiler Error messages generate nice error message for invalid type annotations 1`] = `
+"file:1:4: 'the' is missing the type and value
+(the)
+---^"
+`;
+
+exports[`Compiler Error messages generate nice error message for invalid type annotations 2`] = `
+"file:1:6: 'the' is missing the expression
+(the 3)
+-----^"
+`;
+
+exports[`Compiler Error messages generate nice error message for invalid type annotations 3`] = `
+"file:1:7: 'the' is missing the expression
+(the ID)
+------^"
+`;
+
+exports[`Compiler Error messages generate nice error message for invalid type annotations 4`] = `
+"file:1:6: Not a valid type
+(the 3 3)
+-----^"
+`;
+
+exports[`Compiler Error messages generate nice error message for invalid type annotations 5`] = `
+"file:1:11: Too many arguments. 'the' should take two arguments.
+(the ID 3 3)
+----------^"
+`;
+
 exports[`Compiler Error messages generate nice error message for records with duplicated labels 1`] = `
 "file:1:8: Duplicated label
 {:x 10 :x 20}
 -------^"
+`;
+
+exports[`Compiler Error messages generate nice error messages for invalid exports 1`] = `
+"file:1:7: 'export' needs exactly 1 arguments, got 0
+(export)
+------^"
+`;
+
+exports[`Compiler Error messages generate nice error messages for invalid exports 2`] = `
+"file:1:9: 'export' expected a symbol
+(export 1)
+--------^"
+`;
+
+exports[`Compiler Error messages generate nice error messages for invalid exports 3`] = `
+"file:1:9: 'export' expected a symbol
+(export (+ 1 2))
+--------^"
+`;
+
+exports[`Compiler Error messages generate nice error messages for invalid exports 4`] = `
+"file:1:13: 'export' needs exactly 1 arguments, got 3
+(export 1 2 3)
+------------^"
 `;

--- a/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
@@ -139,6 +139,11 @@ exports[`Pretty Printer should pretty print a combination of lambda and function
                       ttt))))"
 `;
 
+exports[`Pretty Printer should pretty print type declarations 1`] = `
+"
+(type Person {:name string :age number :books [{:name string :author string}]})"
+`;
+
 exports[`Pretty Printer should print amll real code beautifully 1`] = `
 "
 (define bq-frob

--- a/packages/delisp-core/__tests__/compiler.ts
+++ b/packages/delisp-core/__tests__/compiler.ts
@@ -18,9 +18,13 @@ describe("Compiler", () => {
       if (result) {
         return result;
       } else {
-        throw new Error(`FATAL: EXPRESSION DID NOT FAIL TO COMPILE.`);
+        throw new Error(`FATAL: EXPRESSION ${str} DID NOT FAIL TO COMPILE.`);
       }
     }
+
+    it("generate a nice error for some basic invalid syntax", () => {
+      expect(compileError("()")).toMatchSnapshot();
+    });
 
     it("generate nice error message for invalid lambda expressions", () => {
       expect(compileError("(lambda)")).toMatchSnapshot();
@@ -28,6 +32,7 @@ describe("Compiler", () => {
       expect(compileError("(lambda 7 5)")).toMatchSnapshot();
       expect(compileError("(lambda (7) x)")).toMatchSnapshot();
       expect(compileError("(lambda (x 7) x)")).toMatchSnapshot();
+      expect(compileError("(lambda (x x) x)")).toMatchSnapshot();
     });
 
     it("generate nice error message for invalid let expressions", () => {
@@ -43,6 +48,7 @@ describe("Compiler", () => {
       expect(compileError("(define 5)")).toMatchSnapshot();
       expect(compileError("(define x)")).toMatchSnapshot();
       expect(compileError("(define 4 2)")).toMatchSnapshot();
+      expect(compileError("(define x 10 23)")).toMatchSnapshot();
     });
 
     it("generate nice error message for conditionals", () => {
@@ -60,12 +66,30 @@ describe("Compiler", () => {
       expect(compileError("{:x 10 :x 20}")).toMatchSnapshot();
     });
 
+    it("generate nice error message for invalid type annotations", () => {
+      expect(compileError("(the)")).toMatchSnapshot();
+      expect(compileError("(the 3)")).toMatchSnapshot();
+      expect(compileError("(the ID)")).toMatchSnapshot();
+      expect(compileError("(the 3 3)")).toMatchSnapshot();
+      expect(compileError("(the ID 3 3)")).toMatchSnapshot();
+    });
+
     it("generate nice error message for bad type declarations", () => {
       expect(compileError("(type)")).toMatchSnapshot();
       expect(compileError("(type a)")).toMatchSnapshot();
       expect(compileError("(type A)")).toMatchSnapshot();
       expect(compileError("(type A 3)")).toMatchSnapshot();
       expect(compileError("(type a {})")).toMatchSnapshot();
+      expect(compileError("(type ID {} 10)")).toMatchSnapshot();
+      expect(compileError("(type 3 5)")).toMatchSnapshot();
+      expect(compileError("(type ID (-> a a))")).toMatchSnapshot();
+    });
+
+    it("generate nice error messages for invalid exports", () => {
+      expect(compileError("(export)")).toMatchSnapshot();
+      expect(compileError("(export 1)")).toMatchSnapshot();
+      expect(compileError("(export (+ 1 2))")).toMatchSnapshot();
+      expect(compileError("(export 1 2 3)")).toMatchSnapshot();
     });
   });
 });

--- a/packages/delisp-core/__tests__/compiler.ts
+++ b/packages/delisp-core/__tests__/compiler.ts
@@ -1,7 +1,7 @@
-import { readFromString } from "../src/reader";
+import { compileToString, moduleEnvironment } from "../src/compiler";
 import { convert } from "../src/convert";
 import { createModule } from "../src/module";
-import { compileToString, moduleEnvironment } from "../src/compiler";
+import { readFromString } from "../src/reader";
 
 describe("Compiler", () => {
   describe("Error messages", () => {

--- a/packages/delisp-core/__tests__/compiler.ts
+++ b/packages/delisp-core/__tests__/compiler.ts
@@ -59,5 +59,13 @@ describe("Compiler", () => {
     it("generate nice error message for records with duplicated labels", () => {
       expect(compileError("{:x 10 :x 20}")).toMatchSnapshot();
     });
+
+    it("generate nice error message for bad type declarations", () => {
+      expect(compileError("(type)")).toMatchSnapshot();
+      expect(compileError("(type a)")).toMatchSnapshot();
+      expect(compileError("(type A)")).toMatchSnapshot();
+      expect(compileError("(type A 3)")).toMatchSnapshot();
+      expect(compileError("(type a {})")).toMatchSnapshot();
+    });
   });
 });

--- a/packages/delisp-core/__tests__/eval.ts
+++ b/packages/delisp-core/__tests__/eval.ts
@@ -1,7 +1,7 @@
-import { readSyntax } from "../src/index";
-import { evaluate } from "../src/eval";
-import { createModule } from "../src/module";
 import { moduleEnvironment } from "../src/compiler";
+import { evaluate } from "../src/eval";
+import { readSyntax } from "../src/index";
+import { createModule } from "../src/module";
 
 function evaluateString(str: string): any {
   const env = moduleEnvironment(createModule());

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -1,6 +1,6 @@
-import { readSyntax, isDeclaration } from "../src/index";
-import { inferType, ExternalEnvironment } from "../src/infer";
-import { readType, printType } from "../src/type-utils";
+import { isDeclaration, readSyntax } from "../src/index";
+import { ExternalEnvironment, inferType } from "../src/infer";
+import { printType, readType } from "../src/type-utils";
 
 function typeOf(
   str: string,

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -1,8 +1,11 @@
 import { readSyntax, isDeclaration } from "../src/index";
-import { inferType, TypeEnvironment } from "../src/infer";
+import { inferType, ExternalEnvironment } from "../src/infer";
 import { readType, printType } from "../src/type-utils";
 
-function typeOf(str: string, env: TypeEnvironment = {}): string {
+function typeOf(
+  str: string,
+  env: ExternalEnvironment = { variables: {}, types: {} }
+): string {
   const syntax = readSyntax(str);
   if (isDeclaration(syntax)) {
     throw new Error(`Not an expression!`);
@@ -31,9 +34,12 @@ describe("Type inference", () => {
   describe("Function calls", () => {
     it("should have the right type", () => {
       const env = {
-        length: readType("(-> string int)"),
-        "+": readType("(-> number number number)"),
-        const: readType("(-> a (-> b a))")
+        variables: {
+          length: readType("(-> string int)"),
+          "+": readType("(-> number number number)"),
+          const: readType("(-> a (-> b a))")
+        },
+        types: {}
       };
       expect(typeOf("(+ 1 2)", env)).toBe("number");
       expect(typeOf("(+ (+ 1 1) 2)", env)).toBe("number");

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -175,5 +175,15 @@ describe("Type inference", () => {
         );
       });
     });
+
+    describe("Type aliases", () => {
+      it("should preserve the type alias name", () => {
+        const env = {
+          variables: {},
+          types: { ID: readType("number").mono }
+        };
+        expect(typeOf("(the ID 5)", env)).toBe("ID");
+      });
+    });
   });
 });

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -177,11 +177,16 @@ describe("Type inference", () => {
     });
 
     describe("Type aliases", () => {
+      const env = {
+        variables: {},
+        types: { ID: readType("number").mono }
+      };
+
+      it("should unify with their definition", () => {
+        expect(typeOf("(if true (the ID 5) 3)", env)).not.toBe("α");
+      });
+
       it("should preserve the type alias name", () => {
-        const env = {
-          variables: {},
-          types: { ID: readType("number").mono }
-        };
         expect(typeOf("(the ID 5)", env)).toBe("ID");
       });
     });

--- a/packages/delisp-core/__tests__/printer.ts
+++ b/packages/delisp-core/__tests__/printer.ts
@@ -83,7 +83,7 @@ eee
     expect(
       pprintString(
         `
-(define bq-frob 
+(define bq-frob
   (lambda (x)
     (and (consp x) (or (eq (car x) *comma*) (eq (car x) *comma-atsign*)))))
 `

--- a/packages/delisp-core/__tests__/printer.ts
+++ b/packages/delisp-core/__tests__/printer.ts
@@ -173,4 +173,12 @@ eee
       )
     ).toMatchSnapshot();
   });
+
+  it("should pretty print type declarations", () => {
+    expect(
+      pprintString(
+        `(type Person {:name string :age number :books [{:name string :author string}]}) `
+      )
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/delisp-core/__tests__/unify.ts
+++ b/packages/delisp-core/__tests__/unify.ts
@@ -1,4 +1,11 @@
-import { tFn, tNumber, tRecord, tVar, tVector } from "../src/types";
+import {
+  tFn,
+  tNumber,
+  tRecord,
+  tUserDefined,
+  tVar,
+  tVector
+} from "../src/types";
 import { unificationInEnvironment } from "../src/unify";
 
 const unify = unificationInEnvironment(name => {
@@ -9,7 +16,7 @@ describe("Unification", () => {
   it("should perform an occur check", () => {
     const t1 = tVar("t1");
     const t2 = tVector(t1);
-    const result = unify(t1, t2);
+    const result = unify(t1, t2, {});
     expect(result.type).toBe("unify-occur-check-error");
   });
 
@@ -17,13 +24,13 @@ describe("Unification", () => {
     it("should catch function arity mismatches", () => {
       const t1 = tFn([tNumber, tNumber], tNumber);
       const t2 = tFn([tNumber], tNumber);
-      const result = unify(t1, t2);
+      const result = unify(t1, t2, {});
       expect(result.type).toBe("unify-missing-value-error");
     });
     it("should catch operator mismatches", () => {
       const t1 = tVector(tNumber);
       const t2 = tFn([], tNumber);
-      const result = unify(t1, t2);
+      const result = unify(t1, t2, {});
       expect(result.type).toBe("unify-mismatch-error");
     });
   });
@@ -33,7 +40,7 @@ describe("Unification", () => {
       const r = tVar("r");
       const t1 = tRecord([{ label: ":x", type: tNumber }], r);
       const t2 = tRecord([{ label: ":y", type: tNumber }], r);
-      const result = unify(t1, t2);
+      const result = unify(t1, t2, {});
       expect(result.type).toBe("unify-mismatch-error");
     });
 
@@ -44,8 +51,24 @@ describe("Unification", () => {
         [{ label: "z", type: tNumber }, { label: ":y", type: tNumber }],
         r
       );
-      const result = unify(t1, t2);
+      const result = unify(t1, t2, {});
       expect(result.type).toBe("unify-mismatch-error");
+    });
+  });
+
+  describe("Type aliases", () => {
+    const unifyWithA = unificationInEnvironment(_name => {
+      return tNumber;
+    });
+
+    it("should unify with its definition", () => {
+      const t1 = tNumber;
+      const t2 = tUserDefined("A");
+      const result = unifyWithA(t1, t2, { a: tNumber });
+      expect(result.type).toBe("unify-success");
+      if (result.type === "unify-success") {
+        expect(result.substitution).toHaveProperty("a");
+      }
     });
   });
 });

--- a/packages/delisp-core/__tests__/unify.ts
+++ b/packages/delisp-core/__tests__/unify.ts
@@ -1,5 +1,9 @@
 import { tFn, tNumber, tRecord, tVar, tVector } from "../src/types";
-import { unify } from "../src/unify";
+import { unificationInEnvironment } from "../src/unify";
+
+const unify = unificationInEnvironment(name => {
+  throw new Error(`Unkonwn user defined type ${name}`);
+});
 
 describe("Unification", () => {
   it("should perform an occur check", () => {

--- a/packages/delisp-core/jest.config.js
+++ b/packages/delisp-core/jest.config.js
@@ -5,5 +5,10 @@ module.exports = {
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   collectCoverageFrom: ["src/**/*.{ts}"],
-  verbose: true
+  verbose: true,
+  globals: {
+    "ts-jest": {
+      tsConfig: "tsconfig.build.json"
+    }
+  }
 };

--- a/packages/delisp-core/package.json
+++ b/packages/delisp-core/package.json
@@ -4,7 +4,8 @@
   "main": "dist/src/index.js",
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build tsconfig.build.json",
+    "build:all": "tsc --build tsconfig.json",
     "lint": "tslint --project tsconfig.json",
     "test": "jest"
   },

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -3,6 +3,7 @@ import {
   Expression,
   isDefinition,
   isExport,
+  isTypeAlias,
   Module,
   SConditional,
   SDefinition,
@@ -303,18 +304,21 @@ function compileTopLevel(
   syntax: Syntax,
   env: Environment
 ): JS.Statement | null {
-  if (isExport(syntax)) {
+  if (isExport(syntax) || isTypeAlias(syntax)) {
     // exports are compiled at the end of the module
     return null;
   }
 
-  const js: JS.Statement =
-    syntax.type === "definition"
-      ? compileDefinition(syntax, env)
-      : {
-          type: "ExpressionStatement",
-          expression: compile(syntax, env)
-        };
+  let js: JS.Statement;
+
+  if (isDefinition(syntax)) {
+    js = compileDefinition(syntax, env);
+  } else {
+    js = {
+      type: "ExpressionStatement",
+      expression: compile(syntax, env)
+    };
+  }
 
   return {
     ...js,

--- a/packages/delisp-core/src/convert-type.ts
+++ b/packages/delisp-core/src/convert-type.ts
@@ -16,10 +16,41 @@ import {
   tNumber,
   tRecord,
   tString,
+  tUserDefined,
   tVar,
   tVector,
   tVoid
 } from "./types";
+
+/** Capitalize a string like "foo" to "Foo". */
+function capitalize(str: string) {
+  if (str === "") {
+    return "";
+  } else {
+    return str[0].toUpperCase() + str.slice(1);
+  }
+}
+
+/** Return true if a symbol is a valid name for a user defined type, false otherwise. */
+export function userDefinedType(expr: ASExprSymbol): boolean {
+  return expr.name[0] === expr.name[0].toUpperCase();
+}
+
+/** Check if a symbol is a valid user defined type name or throw a user-friendly error otherwise. */
+export function checkUserDefinedTypeName(expr: ASExprSymbol): void {
+  if (!userDefinedType(expr)) {
+    throw new Error(
+      printHighlightedExpr(
+        `'${
+          expr.name
+        }' is not a valid name for a type. Type names should start with a capital letter. Try '${capitalize(
+          expr.name
+        )}'?`,
+        expr.location
+      )
+    );
+  }
+}
 
 function convertSymbol(expr: ASExprSymbol): Monotype {
   switch (expr.name) {
@@ -34,7 +65,7 @@ function convertSymbol(expr: ASExprSymbol): Monotype {
     case "_":
       return generateUniqueTVar(false, "__t");
     default:
-      return tVar(expr.name);
+      return userDefinedType(expr) ? tUserDefined(expr.name) : tVar(expr.name);
   }
 }
 
@@ -89,6 +120,7 @@ function convertMap(expr: ASExprMap): Monotype {
   );
 }
 
+/* Try to convert a S-Expression into a type. */
 export function convert(expr: ASExpr): Monotype {
   switch (expr.type) {
     case "list":

--- a/packages/delisp-core/src/convert-type.ts
+++ b/packages/delisp-core/src/convert-type.ts
@@ -33,7 +33,7 @@ function capitalize(str: string) {
 
 /** Return true if a symbol is a valid name for a user defined type, false otherwise. */
 export function userDefinedType(expr: ASExprSymbol): boolean {
-  return expr.name[0] === expr.name[0].toUpperCase();
+  return /^[A-Z]/.test(expr.name);
 }
 
 /** Check if a symbol is a valid user defined type name or throw a user-friendly error otherwise. */

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -16,7 +16,10 @@ import {
 } from "./syntax";
 import { last } from "./utils";
 
-import { convert as convertType } from "./convert-type";
+import {
+  checkUserDefinedTypeName,
+  convert as convertType
+} from "./convert-type";
 import { parseRecord } from "./convert-utils";
 import { generalize } from "./type-utils";
 
@@ -314,6 +317,8 @@ defineToplevel("type", expr => {
       printHighlightedExpr("'type' expected a symbol as a name", name.location)
     );
   }
+
+  checkUserDefinedTypeName(name);
 
   return {
     type: "type-alias",

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -226,6 +226,16 @@ defineConversion("the", expr => {
     );
   }
 
+  if (args.length > 2) {
+    throw new Error(
+      printHighlightedExpr(
+        `Too many arguments. 'the' should take two arguments.`,
+        args[2].location,
+        true
+      )
+    );
+  }
+
   const [t, value] = args;
 
   return {

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -293,6 +293,36 @@ defineToplevel("export", expr => {
   };
 });
 
+defineToplevel("type", expr => {
+  const [typ, ...args] = expr.elements;
+
+  if (args.length !== 2) {
+    const lastExpr = last([typ, ...args]) as ASExpr;
+    throw new Error(
+      printHighlightedExpr(
+        `'type' needs exactly 2 arguments, got ${args.length}`,
+        lastExpr.location,
+        true
+      )
+    );
+  }
+
+  const [name, alias] = args;
+
+  if (name.type !== "symbol") {
+    throw new Error(
+      printHighlightedExpr("'type' expected a symbol as a name", name.location)
+    );
+  }
+
+  return {
+    type: "type-alias",
+    name: name.name,
+    definition: generalize(convertType(alias), []),
+    location: expr.location
+  };
+});
+
 function convertList(list: ASExprList): Expression {
   if (list.elements.length === 0) {
     throw new Error(

--- a/packages/delisp-core/src/index.ts
+++ b/packages/delisp-core/src/index.ts
@@ -12,7 +12,13 @@ export { createContext, evaluate, evaluateModule } from "./eval";
 export { inferType, inferModule } from "./infer";
 // TODO: replace with the pretty printer
 export { printType } from "./type-utils";
-export { isDeclaration, isDefinition, isExpression } from "./syntax";
+export {
+  isDeclaration,
+  isDefinition,
+  isExpression,
+  isExport,
+  isTypeAlias
+} from "./syntax";
 export { pprintModule } from "./printer";
 
 export { default as primitives } from "./primitives";

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -881,7 +881,7 @@ function groupAssumptions(
   externals: TAssumption[];
   unknowns: TAssumption[];
 } {
-  const internals = assumptions.filter(v => v.name in internalEnv);
+  const internals = assumptions.filter(v => v.name in internalEnv.variables);
   const externals = assumptions.filter(
     v => lookupVariableType(v.name, externalEnv) !== null
   );

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -865,7 +865,7 @@ export function inferType(
   const s = solve(
     [...constraints, ...assumptionsToConstraints(assumptions, env)],
     {},
-    {}
+    env.types
   );
 
   return applySubstitutionToExpr(tmpExpr, s);

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -31,7 +31,7 @@ import {
   tVector,
   Type
 } from "./types";
-import { unify } from "./unify";
+import { unificationInEnvironment } from "./unify";
 import {
   difference,
   flatMap,
@@ -727,6 +727,10 @@ function solve(
   if (constraints.length === 0) {
     return solution;
   }
+
+  const unify = unificationInEnvironment(name => {
+    return typeEnvironment[name];
+  });
 
   // Check if a constraint is solvable.
   //

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -479,7 +479,7 @@ function inferSyntax(syntax: Syntax): InferResult<Syntax<Typed>> {
 // found, so they are supposed to be part of a global environment (or
 // non existing!).
 
-interface ExternalEnvironment {
+export interface ExternalEnvironment {
   variables: {
     [v: string]: Type;
   };

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -448,6 +448,14 @@ function inferSyntax(syntax: Syntax): InferResult<Syntax<Typed>> {
       assumptions,
       constraints
     };
+  } else if (syntax.type === "type-alias") {
+    return {
+      result: {
+        ...syntax
+      },
+      assumptions: [],
+      constraints: []
+    };
   } else {
     const { result, assumptions, constraints } = infer(syntax, []);
     return {
@@ -687,6 +695,8 @@ function applySubstitutionToSyntax(
       ...s,
       value: applySubstitutionToExpr(s.value, env) as SVariableReference<Typed>
     };
+  } else if (s.type === "type-alias") {
+    return s;
   } else {
     return applySubstitutionToExpr(s, env);
   }

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -478,6 +478,7 @@ function inferSyntax(syntax: Syntax): InferResult<Syntax<Typed>> {
 // assumptions. Those assumptions are from variables we have not
 // found, so they are supposed to be part of a global environment (or
 // non existing!).
+
 export interface TypeEnvironment {
   [v: string]: Type;
 }
@@ -873,6 +874,8 @@ export function inferModule(
   const bodyInferences = m.body.map(inferSyntax);
   const body = bodyInferences.map(i => i.result);
 
+  // This environment names of variables defined internally in this
+  // module to their type.
   const internalEnv: {
     [v: string]: Monotype;
   } = body.reduce((env, s) => {

--- a/packages/delisp-core/src/module.ts
+++ b/packages/delisp-core/src/module.ts
@@ -31,3 +31,12 @@ export function removeModuleDefinition(m: Module, name: string): Module {
     })
   };
 }
+
+export function removeModuleTypeDefinition(m: Module, name: string): Module {
+  return {
+    type: "module",
+    body: m.body.filter(d => {
+      return d.type === "type-alias" ? d.name !== name : true;
+    })
+  };
+}

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -155,7 +155,7 @@ function print(sexpr: Syntax): Doc {
           text("type"),
           space,
           text(sexpr.name),
-          indent(concat(line, text(printType(sexpr.definition.mono, false))))
+          indent(concat(line, text(printType(sexpr.definition, false))))
         )
       );
   }

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -148,6 +148,16 @@ function print(sexpr: Syntax): Doc {
           indent(concat(line, print(sexpr.value)))
         )
       );
+
+    case "type-alias":
+      return group(
+        list(
+          text("type"),
+          space,
+          text(sexpr.name),
+          indent(concat(line, text(printType(sexpr.definition.mono, false))))
+        )
+      );
   }
 }
 

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -29,6 +29,8 @@ function syntaxChildren<I>(s: Syntax<I>): Array<Expression<I>> {
       return [s.value];
     case "export":
       return [s.value];
+    case "type-alias":
+      return [];
     default:
       return expressionChildren(s);
   }

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -1,5 +1,5 @@
 import { Location } from "./input";
-import { Type } from "./types";
+import { Monotype, Type } from "./types";
 
 //
 // Expressions
@@ -116,7 +116,7 @@ export interface SExport<I = {}> {
 export interface STypeAlias<_I> {
   type: "type-alias";
   name: SVar;
-  definition: Type;
+  definition: Monotype;
   location: Location;
 }
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -113,11 +113,22 @@ export interface SExport<I = {}> {
   location: Location;
 }
 
-export type Declaration<I = {}> = SDefinition<I> | SExport<I>;
+export interface STypeAlias<_I> {
+  type: "type-alias";
+  name: SVar;
+  definition: Type;
+  location: Location;
+}
+
+export type Declaration<I = {}> = SDefinition<I> | SExport<I> | STypeAlias<I>;
 export type Syntax<I = {}> = Expression<I> | Declaration<I>;
 
 export function isDeclaration<I>(syntax: Syntax<I>): syntax is Declaration<I> {
-  return syntax.type === "definition" || syntax.type === "export";
+  return (
+    syntax.type === "definition" ||
+    syntax.type === "export" ||
+    syntax.type === "type-alias"
+  );
 }
 
 export function isExpression<I>(syntax: Syntax<I>): syntax is Expression<I> {
@@ -130,6 +141,10 @@ export function isDefinition<I>(syntax: Syntax<I>): syntax is SDefinition<I> {
 
 export function isExport<I>(syntax: Syntax<I>): syntax is SExport<I> {
   return syntax.type === "export";
+}
+
+export function isTypeAlias<I>(syntax: Syntax<I>): syntax is STypeAlias<I> {
+  return syntax.type === "type-alias";
 }
 
 export interface Module<I = {}> {

--- a/packages/delisp-core/src/type-substitution.ts
+++ b/packages/delisp-core/src/type-substitution.ts
@@ -1,4 +1,5 @@
 import { Monotype, tApp, tRowExtension } from "./types";
+
 export interface Substitution {
   [t: string]: Monotype;
 }
@@ -20,6 +21,8 @@ export function applySubstitution(t: Monotype, env: Substitution): Monotype {
         return t;
       }
     }
+    case "user-defined-type":
+      return t;
     case "empty-row":
       return t;
     case "row-extension":

--- a/packages/delisp-core/src/type-utils.ts
+++ b/packages/delisp-core/src/type-utils.ts
@@ -12,6 +12,7 @@ export function listTypeVariables(t: Monotype): string[] {
     case "boolean":
     case "string":
     case "number":
+    case "user-defined-type":
     case "empty-row":
       return [];
     case "application":
@@ -130,6 +131,8 @@ function _printType(type: Monotype): string {
     case "string":
       return "string";
     case "type-variable":
+      return type.name;
+    case "user-defined-type":
       return type.name;
     case "empty-row":
     case "row-extension":

--- a/packages/delisp-core/src/type-utils.ts
+++ b/packages/delisp-core/src/type-utils.ts
@@ -39,12 +39,17 @@ export function generalize(t: Monotype, monovars: string[]): Type {
   };
 }
 
+export function isWildcardTypeVarName(name: string): boolean {
+  return name.startsWith("_");
+}
+
 export function instantiate(t: Type, userSpecified = false): Monotype {
   const subst = t.tvars.reduce((s, vname) => {
-    const isHole = vname.startsWith("_");
     return {
       ...s,
-      [vname]: generateUniqueTVar(isHole ? false : userSpecified)
+      [vname]: generateUniqueTVar(
+        isWildcardTypeVarName(vname) ? false : userSpecified
+      )
     };
   }, {});
   return applySubstitution(t.mono, subst);

--- a/packages/delisp-core/src/types.ts
+++ b/packages/delisp-core/src/types.ts
@@ -29,6 +29,11 @@ export interface TVar {
   userSpecified: boolean;
 }
 
+export interface TUserDefined {
+  type: "user-defined-type";
+  name: string;
+}
+
 export interface REmpty {
   type: "empty-row";
 }
@@ -50,7 +55,8 @@ export type Monotype =
   | TApplication
   | TVar
   | Row
-  | TVoid;
+  | TVoid
+  | TUserDefined;
 
 export interface Type {
   type: "type";
@@ -83,6 +89,13 @@ export function tVar(name: string, userSpecified = false): TVar {
     type: "type-variable",
     name,
     userSpecified
+  };
+}
+
+export function tUserDefined(name: string): TUserDefined {
+  return {
+    type: "user-defined-type",
+    name
   };
 }
 

--- a/packages/delisp-core/src/unify.ts
+++ b/packages/delisp-core/src/unify.ts
@@ -223,11 +223,7 @@ export function unificationInEnvironment(
    * the most general one, in the sense that any other substitution can
    * be obtained as a composition of this one with another one.
    */
-  function unify(
-    t1: Monotype,
-    t2: Monotype,
-    ctx: Substitution = {}
-  ): UnifyResult {
+  function unify(t1: Monotype, t2: Monotype, ctx: Substitution): UnifyResult {
     // RULE (uni-const)
     if (t1.type === "string" && t2.type === "string") {
       return success(ctx);
@@ -271,9 +267,9 @@ export function unificationInEnvironment(
       // RULE: (uni-varr)
       return unifyVariable(t2, t1, ctx);
     } else if (t1.type === "user-defined-type") {
-      return unify(lookupUserDefinedType(t1.name), t2);
+      return unify(lookupUserDefinedType(t1.name), t2, ctx);
     } else if (t2.type === "user-defined-type") {
-      return unify(t1, lookupUserDefinedType(t2.name));
+      return unify(t1, lookupUserDefinedType(t2.name), ctx);
     } else if (t1.type === "empty-row" && t2.type === "empty-row") {
       // RULE (uni-const)
       return success(ctx);

--- a/packages/delisp-core/src/unify.ts
+++ b/packages/delisp-core/src/unify.ts
@@ -71,211 +71,223 @@ function occurCheck(v: TVar, rootT: Monotype): UnifyOccurCheckError | null {
   return check(rootT);
 }
 
-function unifyVariable(v: TVar, t: Monotype, ctx: Substitution): UnifyResult {
-  if (v.name in ctx) {
-    return unify(ctx[v.name], t, ctx);
+export function unificationInEnvironment(
+  lookupUserDefinedType: (name: string) => Monotype
+) {
+  //
+  //
+  function unifyVariable(v: TVar, t: Monotype, ctx: Substitution): UnifyResult {
+    if (v.name in ctx) {
+      return unify(ctx[v.name], t, ctx);
+    }
+    if (t.type === "type-variable") {
+      if (v.name === t.name) {
+        return success(ctx);
+      } else if (t.name in ctx) {
+        return unifyVariable(v, ctx[t.name], ctx);
+      } else {
+        return success({ ...ctx, [v.name]: t });
+      }
+    } else {
+      const err = occurCheck(v, t);
+      if (err) {
+        return err;
+      } else {
+        return success({ ...ctx, [v.name]: t });
+      }
+    }
   }
-  if (t.type === "type-variable") {
-    if (v.name === t.name) {
+
+  function unifyArray(
+    t1s: Monotype[],
+    t2s: Monotype[],
+    ctx: Substitution
+  ): UnifyResult {
+    if (t1s.length === 0 && t2s.length === 0) {
       return success(ctx);
-    } else if (t.name in ctx) {
-      return unifyVariable(v, ctx[t.name], ctx);
-    } else {
-      return success({ ...ctx, [v.name]: t });
-    }
-  } else {
-    const err = occurCheck(v, t);
-    if (err) {
-      return err;
-    } else {
-      return success({ ...ctx, [v.name]: t });
-    }
-  }
-}
-
-function unifyArray(
-  t1s: Monotype[],
-  t2s: Monotype[],
-  ctx: Substitution
-): UnifyResult {
-  if (t1s.length === 0 && t2s.length === 0) {
-    return success(ctx);
-  } else if (t1s.length === 0) {
-    return {
-      type: "unify-missing-value-error",
-      t: t2s[0]
-    };
-  } else if (t2s.length === 0) {
-    return {
-      type: "unify-missing-value-error",
-      t: t1s[0]
-    };
-  } else {
-    const [t1, ...rest1] = t1s;
-    const [t2, ...rest2] = t2s;
-    const result = unify(t1, t2, ctx);
-    if (result.type === "unify-success") {
-      return unifyArray(rest1, rest2, result.substitution);
-    } else {
-      return result;
-    }
-  }
-}
-
-/** Rewrite `row` to be a row staring with `label`.
- *
- * @returns an extension row, together with a subsitution that will
- * partially unify it with `row` (only the head of the extension).
- */
-function rewriteRowForLabel(
-  row: Monotype,
-  label: string,
-  ctx: Substitution
-): { row: RExtension; substitution: Substitution } {
-  if (row.type === "type-variable") {
-    // RULE (row-var)
-    //
-    // If `row` is a variable. We create a fresh row extension
-    //
-    //    {label: γ | β}
-    //
-    // and map that variable to the row in the substitution.
-    const gamma = generateUniqueTVar();
-    const beta = generateUniqueTVar();
-    const theta = tRowExtension(label, gamma, beta);
-    return {
-      row: theta,
-      substitution: { ...ctx, [row.name]: theta }
-    };
-  } else if (row.type === "row-extension") {
-    // RULE (row-head)
-    //
-    // If the `row` is already a row extension starting with the same
-    // label, we are done.
-    //
-    if (row.label === label) {
+    } else if (t1s.length === 0) {
       return {
-        row,
-        substitution: ctx
+        type: "unify-missing-value-error",
+        t: t2s[0]
+      };
+    } else if (t2s.length === 0) {
+      return {
+        type: "unify-missing-value-error",
+        t: t1s[0]
       };
     } else {
-      // RULE (row-swap)
-      //
-      // Firstly, we recursively rewrite the tail of the row extension
-      // to start with `label.`
-      const { row: newRow, substitution: subs } = rewriteRowForLabel(
-        row.extends,
-        label,
-        ctx
-      );
-      //
-      // The resulting row, starts with the intended label, and
-      // continues with the original label that we found.
-      return {
-        row: tRowExtension(
-          label,
-          newRow.labelType,
-          tRowExtension(row.label, row.labelType, newRow.extends)
-        ),
-        substitution: subs
-      };
+      const [t1, ...rest1] = t1s;
+      const [t2, ...rest2] = t2s;
+      const result = unify(t1, t2, ctx);
+      if (result.type === "unify-success") {
+        return unifyArray(rest1, rest2, result.substitution);
+      } else {
+        return result;
+      }
     }
-  } else {
-    throw new Error("Should not get here");
-  }
-}
-
-function unifyRow(
-  row1: RExtension,
-  row2: RExtension,
-  ctx: Substitution
-): UnifyResult {
-  const { substitution: subs, row: row3 } = rewriteRowForLabel(
-    row2,
-    row1.label,
-    ctx
-  );
-
-  if (row1.extends.type === "type-variable" && subs[row1.extends.name]) {
-    return {
-      type: "unify-mismatch-error",
-      t1: row1,
-      t2: row2
-    };
   }
 
-  return unifyArray(
-    [row1.labelType, row1.extends],
-    [row3.labelType, row3.extends],
-    subs
-  );
-}
-
-/** Compute the the most general unifier that unifies t1 and t2.
- *
- * @description The resulting subsitution, applied with
- * `applySubstitution` to t1 and t2 will make them equal. It is also
- * the most general one, in the sense that any other substitution can
- * be obtained as a composition of this one with another one.
- */
-export function unify(
-  t1: Monotype,
-  t2: Monotype,
-  ctx: Substitution = {}
-): UnifyResult {
-  // RULE (uni-const)
-  if (t1.type === "string" && t2.type === "string") {
-    return success(ctx);
-  } else if (t1.type === "number" && t2.type === "number") {
-    return success(ctx);
-  } else if (t1.type === "boolean" && t2.type === "boolean") {
-    return success(ctx);
-  } else if (
-    t1.type === "type-variable" &&
-    t1.userSpecified &&
-    t2.type === "type-variable" &&
-    t2.userSpecified
-  ) {
-    return t1 === t2
-      ? success(ctx)
-      : {
-          type: "unify-mismatch-error",
-          t1,
-          t2
+  /** Rewrite `row` to be a row staring with `label`.
+   *
+   * @returns an extension row, together with a subsitution that will
+   * partially unify it with `row` (only the head of the extension).
+   */
+  function rewriteRowForLabel(
+    row: Monotype,
+    label: string,
+    ctx: Substitution
+  ): { row: RExtension; substitution: Substitution } {
+    if (row.type === "type-variable") {
+      // RULE (row-var)
+      //
+      // If `row` is a variable. We create a fresh row extension
+      //
+      //    {label: γ | β}
+      //
+      // and map that variable to the row in the substitution.
+      const gamma = generateUniqueTVar();
+      const beta = generateUniqueTVar();
+      const theta = tRowExtension(label, gamma, beta);
+      return {
+        row: theta,
+        substitution: { ...ctx, [row.name]: theta }
+      };
+    } else if (row.type === "row-extension") {
+      // RULE (row-head)
+      //
+      // If the `row` is already a row extension starting with the same
+      // label, we are done.
+      //
+      if (row.label === label) {
+        return {
+          row,
+          substitution: ctx
         };
-  } else if (
-    t1.type === "application" &&
-    t2.type === "application" &&
-    t1.op === t2.op
-  ) {
-    // RULE: (uni-app)
-    const argResult = unifyArray(
-      t1.args.slice(0, t1.args.length - 1),
-      t2.args.slice(0, t2.args.length - 1),
+      } else {
+        // RULE (row-swap)
+        //
+        // Firstly, we recursively rewrite the tail of the row extension
+        // to start with `label.`
+        const { row: newRow, substitution: subs } = rewriteRowForLabel(
+          row.extends,
+          label,
+          ctx
+        );
+        //
+        // The resulting row, starts with the intended label, and
+        // continues with the original label that we found.
+        return {
+          row: tRowExtension(
+            label,
+            newRow.labelType,
+            tRowExtension(row.label, row.labelType, newRow.extends)
+          ),
+          substitution: subs
+        };
+      }
+    } else {
+      throw new Error("Should not get here");
+    }
+  }
+
+  function unifyRow(
+    row1: RExtension,
+    row2: RExtension,
+    ctx: Substitution
+  ): UnifyResult {
+    const { substitution: subs, row: row3 } = rewriteRowForLabel(
+      row2,
+      row1.label,
       ctx
     );
-    if (argResult.type === "unify-success") {
-      return unify(last(t1.args)!, last(t2.args)!, argResult.substitution);
-    } else {
-      return argResult;
+
+    if (row1.extends.type === "type-variable" && subs[row1.extends.name]) {
+      return {
+        type: "unify-mismatch-error",
+        t1: row1,
+        t2: row2
+      };
     }
-  } else if (t1.type === "type-variable" && !t1.userSpecified) {
-    // RULE: (uni-varl)
-    return unifyVariable(t1, t2, ctx);
-  } else if (t2.type === "type-variable" && !t2.userSpecified) {
-    // RULE: (uni-varr)
-    return unifyVariable(t2, t1, ctx);
-  } else if (t1.type === "empty-row" && t2.type === "empty-row") {
-    // RULE (uni-const)
-    return success(ctx);
-  } else if (t1.type === "row-extension" && t2.type === "row-extension") {
-    // RULE: (uni-row)
-    return unifyRow(t1, t2, ctx);
-  } else {
-    return {
-      type: "unify-mismatch-error",
-      t1,
-      t2
-    };
+
+    return unifyArray(
+      [row1.labelType, row1.extends],
+      [row3.labelType, row3.extends],
+      subs
+    );
   }
+
+  /** Compute the the most general unifier that unifies t1 and t2.
+   *
+   * @description The resulting subsitution, applied with
+   * `applySubstitution` to t1 and t2 will make them equal. It is also
+   * the most general one, in the sense that any other substitution can
+   * be obtained as a composition of this one with another one.
+   */
+  function unify(
+    t1: Monotype,
+    t2: Monotype,
+    ctx: Substitution = {}
+  ): UnifyResult {
+    // RULE (uni-const)
+    if (t1.type === "string" && t2.type === "string") {
+      return success(ctx);
+    } else if (t1.type === "number" && t2.type === "number") {
+      return success(ctx);
+    } else if (t1.type === "boolean" && t2.type === "boolean") {
+      return success(ctx);
+    } else if (
+      t1.type === "type-variable" &&
+      t1.userSpecified &&
+      t2.type === "type-variable" &&
+      t2.userSpecified
+    ) {
+      return t1 === t2
+        ? success(ctx)
+        : {
+            type: "unify-mismatch-error",
+            t1,
+            t2
+          };
+    } else if (
+      t1.type === "application" &&
+      t2.type === "application" &&
+      t1.op === t2.op
+    ) {
+      // RULE: (uni-app)
+      const argResult = unifyArray(
+        t1.args.slice(0, t1.args.length - 1),
+        t2.args.slice(0, t2.args.length - 1),
+        ctx
+      );
+      if (argResult.type === "unify-success") {
+        return unify(last(t1.args)!, last(t2.args)!, argResult.substitution);
+      } else {
+        return argResult;
+      }
+    } else if (t1.type === "type-variable" && !t1.userSpecified) {
+      // RULE: (uni-varl)
+      return unifyVariable(t1, t2, ctx);
+    } else if (t2.type === "type-variable" && !t2.userSpecified) {
+      // RULE: (uni-varr)
+      return unifyVariable(t2, t1, ctx);
+    } else if (t1.type === "user-defined-type") {
+      return unify(lookupUserDefinedType(t1.name), t2);
+    } else if (t2.type === "user-defined-type") {
+      return unify(t1, lookupUserDefinedType(t2.name));
+    } else if (t1.type === "empty-row" && t2.type === "empty-row") {
+      // RULE (uni-const)
+      return success(ctx);
+    } else if (t1.type === "row-extension" && t2.type === "row-extension") {
+      // RULE: (uni-row)
+      return unifyRow(t1, t2, ctx);
+    } else {
+      return {
+        type: "unify-mismatch-error",
+        t1,
+        t2
+      };
+    }
+  }
+
+  return unify;
 }

--- a/packages/delisp-core/tsconfig.build.json
+++ b/packages/delisp-core/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["./src/"],
+  "references": [{ "path": "../delisp-runtime" }]
+}

--- a/packages/delisp-core/tsconfig.json
+++ b/packages/delisp-core/tsconfig.json
@@ -1,9 +1,7 @@
 {
-  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "declaration": true
+    "noEmit": true
   },
-  "include": ["./src/"],
-  "references": [{ "path": "../delisp-runtime" }]
+  "extends": "./tsconfig.build.json",
+  "include": ["./__tests__", "./src/"]
 }

--- a/packages/delisp/src/cmd-infer-type.ts
+++ b/packages/delisp/src/cmd-infer-type.ts
@@ -3,8 +3,10 @@ import { CommandModule } from "yargs";
 import {
   findSyntaxByOffset,
   inferModule,
-  isDeclaration,
+  isDefinition,
+  isExport,
   isExpression,
+  isTypeAlias,
   printType,
   readModule
 } from "@delisp/core";
@@ -54,7 +56,11 @@ export const cmdInferType: CommandModule = {
     if (s) {
       if (isExpression(s)) {
         console.log(printType(s.info.type));
-      } else if (isDeclaration(s)) {
+      } else if (isTypeAlias(s)) {
+        console.log(s);
+      } else if (isDefinition(s)) {
+        console.log(printType(s.value.info.type));
+      } else if (isExport(s)) {
         console.log(printType(s.value.info.type));
       }
     }

--- a/packages/delisp/src/cmd-repl.ts
+++ b/packages/delisp/src/cmd-repl.ts
@@ -155,7 +155,7 @@ const delispEval = (syntax: Syntax) => {
 
   if (isDeclaration(syntax)) {
     const type =
-      typedSyntax && isDeclaration(typedSyntax)
+      typedSyntax && isDefinition(typedSyntax)
         ? typedSyntax.value.info.type
         : null;
 

--- a/packages/delisp/src/cmd-repl.ts
+++ b/packages/delisp/src/cmd-repl.ts
@@ -19,7 +19,8 @@ import {
   printType,
   readModule,
   readSyntax,
-  removeModuleDefinition
+  removeModuleDefinition,
+  removeModuleTypeDefinition
 } from "@delisp/core";
 
 import { Typed } from "@delisp/core/src/infer";
@@ -118,10 +119,14 @@ const delispEval = (syntax: Syntax) => {
     previousModule = removeModuleDefinition(previousModule, syntax.variable);
     previousModule = addToModule(previousModule, syntax);
     m = previousModule;
+  } else if (syntax.type === "type-alias") {
+    previousModule = removeModuleTypeDefinition(previousModule, syntax.name);
+    previousModule = addToModule(previousModule, syntax);
+    m = previousModule;
   } else if (isExpression(syntax)) {
     m = addToModule(previousModule, syntax);
   } else {
-    m = previousModule;
+    throw new Error(`I don't know how to handle this in the REPL.`);
   }
 
   let typedModule: Module<Typed> | undefined;

--- a/packages/delisp/tsconfig.json
+++ b/packages/delisp/tsconfig.json
@@ -5,6 +5,6 @@
   },
   "include": ["./src/"],
   "references": [
-    { "path": "../delisp-core" }
+    { "path": "../delisp-core/tsconfig.build.json" }
   ]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -3,7 +3,7 @@
   "include": [],
   "references": [
     { "path": "delisp/" },
-    { "path": "delisp-core/" },
+    { "path": "delisp-core/tsconfig.build.json" },
     { "path": "delisp-runtime/" }
   ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -16,7 +16,8 @@
         "allow-leading-underscore",
         "allow-pascal-case"
       ]
-    }
+    },
+    "max-line-length": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Syntax:

```lisp
(type Person {:name string :age number})
```

A lot of changes and refactoring going on here. To guide you through the changes:
- Introduce type `tUserDefined`, different from type variables.
- Capitalized symbols are read as user defined types. (`Person` vs `a`).
- `inferModule` gathers type alias definitions and build an `InternalEnvironment`.
- This is passed to `unifyInEnvironment`.
- `unify` will consider user defined types as equal to their definition.

## Pending
- [X] ~Add more tests cases because coverage decreased quite a lot.~ . I forgot a `it.only` in the code :-) 

## Limitations
Type aliases can't be propagated as I expected. Consider

```lisp
(type ID number)
(if true (the ID 5) 3)
```

The type of the second `if` is "ambiguosly" ID or number. And indeed it gets more complex so I think there is no easy way to propagate it.  

**Does it invalidate the whole approach???** It could be... but this need this machinery for non-alias user defined types as well I think?  Maybe it could be simplified a bit.

