### PR TITLE
Fix reading symbol starting with number

### DIFF
--- a/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
@@ -163,13 +163,13 @@ exports[`Compiler Error messages generate nice error message for invalid let exp
 `;
 
 exports[`Compiler Error messages generate nice error message for invalid let expressions 4`] = `
-"file:1:9: Expected a digit, or an alphanumeric character
+"file:1:9: Expected an alphanumeric character
 (let {x} x)
 --------^"
 `;
 
 exports[`Compiler Error messages generate nice error message for invalid let expressions 5`] = `
-"file:1:13: Expected a digit, or an alphanumeric character
+"file:1:13: Expected an alphanumeric character
 (let {a b c} x)
 ------------^"
 `;

--- a/packages/delisp-core/__tests__/__snapshots__/reader.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/reader.ts.snap
@@ -13,7 +13,7 @@ exports[`Reader Error messages generate user-friendly error for a closing parent
 `;
 
 exports[`Reader Error messages generate user-friendly error for an incomplete list 1`] = `
-"file:1:7: Expected close parenthesis, number, double quote, symbol, list, open parenthesis, open square bracket, or open curly brace
+"file:1:7: Expected close parenthesis, number or symbol, double quote, list, open parenthesis, open square bracket, or open curly brace
 (1 2 3
 ------^"
 `;

--- a/packages/delisp-core/__tests__/reader.ts
+++ b/packages/delisp-core/__tests__/reader.ts
@@ -76,6 +76,12 @@ describe("Reader", () => {
       location: { start: 2, end: 4 }
     });
 
+    expect(readFromString("  3d  ")).toMatchObject({
+      type: "symbol",
+      name: "3d",
+      location: { start: 2, end: 4 }
+    });
+
     expect(readFromString("  $bc  ")).toMatchObject({
       type: "symbol",
       name: "$bc",

--- a/packages/delisp-core/__tests__/reader.ts
+++ b/packages/delisp-core/__tests__/reader.ts
@@ -47,6 +47,16 @@ describe("Reader", () => {
       value: -12,
       location: { start: 2, end: 5 }
     });
+    expect(readFromString("  0.05  ")).toMatchObject({
+      type: "number",
+      value: 0.05,
+      location: { start: 2, end: 6 }
+    });
+    expect(readFromString("  -0.9  ")).toMatchObject({
+      type: "number",
+      value: -0.9,
+      location: { start: 2, end: 6 }
+    });
   });
 
   it("should read strings", () => {

--- a/packages/delisp-core/src/reader.ts
+++ b/packages/delisp-core/src/reader.ts
@@ -137,10 +137,10 @@ const numberOrSymbol: Parser<ASExprSymbol | ASExprNumber> = atLeastOne(
   .map(
     (chars, location): ASExprSymbol | ASExprNumber => {
       const str = chars.join("");
-      if (/^\-?[0-9]+$/.test(str)) {
+      if (/^\-?[0-9]+(\.[0-9]+)?$/.test(str)) {
         return {
           type: "number",
-          value: parseInt(str, 10),
+          value: parseFloat(str),
           location
         };
       } else {


### PR DESCRIPTION
The reader considers `1a` to be a valid number (1) followed by a valid symbol (a). We should either detect this as an invalid number/symbol, or allow it and parse it completely as a single symbol.