### PR TITLE
Use map for let bindings

### DIFF
--- a/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
@@ -85,27 +85,27 @@ exports[`Compiler Error messages generate nice error message for invalid let exp
 `;
 
 exports[`Compiler Error messages generate nice error message for invalid let expressions 2`] = `
-"file:1:6: 'let' bindings should be a list
+"file:1:6: 'let' bindings should be a map
 (let x 5)
 -----^"
 `;
 
 exports[`Compiler Error messages generate nice error message for invalid let expressions 3`] = `
-"file:1:7: 'let' binding should be a list
-(let (x) x)
-------^"
+"file:1:6: 'let' bindings should be a map
+(let (x 5) x)
+-----^"
 `;
 
 exports[`Compiler Error messages generate nice error message for invalid let expressions 4`] = `
-"file:1:8: expected a symbol
-(let ((5 5)) x)
--------^"
+"file:1:9: Expected a digit, or an alphanumeric character
+(let {x} x)
+--------^"
 `;
 
 exports[`Compiler Error messages generate nice error message for invalid let expressions 5`] = `
-"file:1:7: ill-formed let binding
-(let ((x)) x)
-------^"
+"file:1:13: Expected a digit, or an alphanumeric character
+(let {a b c} x)
+------------^"
 `;
 
 exports[`Compiler Error messages generate nice error message for invalid records 1`] = `

--- a/packages/delisp-core/__tests__/compiler.ts
+++ b/packages/delisp-core/__tests__/compiler.ts
@@ -33,9 +33,9 @@ describe("Compiler", () => {
     it("generate nice error message for invalid let expressions", () => {
       expect(compileError("(let)")).toMatchSnapshot();
       expect(compileError("(let x 5)")).toMatchSnapshot();
-      expect(compileError("(let (x) x)")).toMatchSnapshot();
-      expect(compileError("(let ((5 5)) x)")).toMatchSnapshot();
-      expect(compileError("(let ((x)) x)")).toMatchSnapshot();
+      expect(compileError("(let (x 5) x)")).toMatchSnapshot();
+      expect(compileError("(let {x} x)")).toMatchSnapshot();
+      expect(compileError("(let {a b c} x)")).toMatchSnapshot();
     });
 
     it("generate nice error message for invalid definitions", () => {

--- a/packages/delisp-core/__tests__/eval.ts
+++ b/packages/delisp-core/__tests__/eval.ts
@@ -56,13 +56,13 @@ describe("Evaluation", () => {
 
   describe("Let bindings", () => {
     it("should evaluate to the right value", () => {
-      expect(evaluateString("(let () 5)")).toBe(5);
-      expect(evaluateString("(let ((x 5)) x)")).toBe(5);
-      expect(evaluateString("(let ((x 5) (y 5)) (+ x y))")).toBe(10);
+      expect(evaluateString("(let {} 5)")).toBe(5);
+      expect(evaluateString("(let {x 5} x)")).toBe(5);
+      expect(evaluateString("(let {x 4 y 6} (+ x y))")).toBe(10);
       expect(
         evaluateString(`
-(let ((const (lambda (x)
-               (lambda (y) x))))
+(let {const (lambda (x)
+              (lambda (y) x))}
   (+ ((const 10) "foo")
      ((const 20) 42)))
 `)
@@ -70,7 +70,7 @@ describe("Evaluation", () => {
     });
 
     it("inner lets should shadow outer ones", () => {
-      expect(evaluateString("(let ((x 5)) (let ((x 1)) x))")).toBe(1);
+      expect(evaluateString("(let {x 5} (let {x 1} x))")).toBe(1);
     });
   });
 

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -65,7 +65,7 @@ describe("Type inference", () => {
 
     describe("Let polymorphism", () => {
       it("should generalize basic types in let", () => {
-        expect(typeOf("(let ((id (lambda (x) x))) id)")).toBe("(-> α α)");
+        expect(typeOf("(let {id (lambda (x) x)} id)")).toBe("(-> α α)");
       });
     });
 

--- a/packages/delisp-core/__tests__/printer.ts
+++ b/packages/delisp-core/__tests__/printer.ts
@@ -83,7 +83,7 @@ eee
     expect(
       pprintString(
         `
-(define bq-frob 
+(define bq-frob
   (lambda (x)
     (and (consp x) (or (eq (car x) *comma*) (eq (car x) *comma-atsign*)))))
 `
@@ -120,7 +120,7 @@ eee
   });
 
   it("should print let expressions nicely", () => {
-    expect(pprintString(`(let ((x 10) (y 20)) (+ x y))`)).toMatchSnapshot();
+    expect(pprintString(`(let {x 10 y 20} (+ x y))`)).toMatchSnapshot();
   });
 
   it("should print conditional expressions nicely", () => {
@@ -148,8 +148,8 @@ eee
   (lambda (fn x)
     (if (atom x)
           (funcall fn x)
-          (let ((a (funcall fn (car x)))
-                (d (maptree fn (cdr x))))
+          (let {a (funcall fn (car x))
+                d (maptree fn (cdr x))}
             (if (and (eql a (car x)) (eql d (cdr x)))
                 x
                 (cons a d))))))

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -137,40 +137,17 @@ defineConversion("if", expr => {
 });
 
 function parseLetBindings(bindings: ASExpr): SLetBinding[] {
-  if (bindings.type !== "list") {
+  if (bindings.type !== "map") {
     throw new Error(
-      printHighlightedExpr(`'let' bindings should be a list`, bindings.location)
+      printHighlightedExpr(`'let' bindings should be a map`, bindings.location)
     );
   }
 
-  const output: SLetBinding[] = [];
-
-  bindings.elements.forEach(binding => {
-    if (binding.type !== "list") {
-      throw new Error(
-        printHighlightedExpr(`'let' binding should be a list`, binding.location)
-      );
-    }
-    if (binding.elements.length !== 2) {
-      throw new Error(
-        printHighlightedExpr(`ill-formed let binding`, binding.location)
-      );
-    }
-
-    const [name, value] = binding.elements;
-
-    if (name.type !== "symbol") {
-      throw new Error(printHighlightedExpr(`expected a symbol`, name.location));
-    }
-
-    output.push({
-      var: name.name,
-      value: convertExpr(value),
-      location: binding.location
-    });
-  });
-
-  return output;
+  return bindings.fields.map(field => ({
+    var: field.label.name,
+    value: convertExpr(field.value),
+    location: field.label.location
+  }));
 }
 
 defineConversion("let", expr => {
@@ -189,12 +166,10 @@ defineConversion("let", expr => {
 
   const [rawBindings, ...rawBody] = args;
 
-  const body = parseBody(lastExpr, rawBody);
-
   return {
     type: "let-bindings",
     bindings: parseLetBindings(rawBindings),
-    body,
+    body: parseBody(lastExpr, rawBody),
     location: expr.location,
     info: {}
   };


### PR DESCRIPTION
Changes the let-bindings syntax from
```
(let ((x 1)
      (y 2)
      (z 3))
  body)
```
into using a map:
```
(let {x 1
      y 2
      z 3}
  body)
```
