### PR TITLE
Type alias expansion and user-defined data types

### DIFF
--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -181,6 +181,18 @@ describe("Type inference", () => {
       });
     });
 
+    describe("User-defined type", () => {
+      const env = { variables: {}, types: { ID: readType("number").mono } };
+
+      it("should NOT be compatible", () => {
+        expect(() => typeOf("(if true (the ID 5) 3)", env)).toThrow();
+      });
+
+      it("should NOT expand to their definition", () => {
+        expect(typeOf("(lambda (x) (the ID x))", env)).toBe("(-> ID ID)");
+      });
+    });
+
     describe("Type aliases", () => {
       const env = { variables: {}, types: {} };
       const intEnv: InternalTypeEnvironment = {

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -182,17 +182,17 @@ describe("Type inference", () => {
     });
 
     describe("Type aliases", () => {
-      const env = {
-        variables: {},
-        types: { ID: readType("number").mono }
+      const env = { variables: {}, types: {} };
+      const intEnv: InternalTypeEnvironment = {
+        ID: readType("number").mono
       };
 
-      it("should unify with their definition", () => {
-        expect(typeOf("(if true (the ID 5) 3)", env)).not.toBe("α");
+      it("should be compatible if they are internal", () => {
+        expect(typeOf("(if true (the ID 5) 3)", env, intEnv)).not.toBe("α");
       });
 
-      it("should preserve the type alias name", () => {
-        expect(typeOf("(the ID 5)", env)).toBe("ID");
+      it("should expand to their definition if they are internal", () => {
+        expect(typeOf("(the ID 5)", env, intEnv)).toBe("number");
       });
     });
   });

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -197,7 +197,7 @@ describe("Type inference", () => {
       const env = { variables: {}, types: {} };
       const intEnv: InternalTypeEnvironment = {
         ID: readType("number").mono,
-        Person: readType("{:x string}").mono
+        Person: readType("{:name string}").mono
       };
 
       it("should be compatible if they are internal", () => {

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -1,16 +1,21 @@
 import { isDeclaration, readSyntax } from "../src/index";
-import { ExternalEnvironment, inferType } from "../src/infer";
+import {
+  ExternalEnvironment,
+  inferType,
+  InternalTypeEnvironment
+} from "../src/infer";
 import { printType, readType } from "../src/type-utils";
 
 function typeOf(
   str: string,
-  env: ExternalEnvironment = { variables: {}, types: {} }
+  externalEnv: ExternalEnvironment = { variables: {}, types: {} },
+  internalEnv: InternalTypeEnvironment = {}
 ): string {
   const syntax = readSyntax(str);
   if (isDeclaration(syntax)) {
     throw new Error(`Not an expression!`);
   }
-  const typedExpr = inferType(syntax, env);
+  const typedExpr = inferType(syntax, externalEnv, internalEnv);
   return printType(typedExpr.info.type);
 }
 

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -196,7 +196,8 @@ describe("Type inference", () => {
     describe("Type aliases", () => {
       const env = { variables: {}, types: {} };
       const intEnv: InternalTypeEnvironment = {
-        ID: readType("number").mono
+        ID: readType("number").mono,
+        Person: readType("{:x string}").mono
       };
 
       it("should be compatible if they are internal", () => {
@@ -205,6 +206,12 @@ describe("Type inference", () => {
 
       it("should expand to their definition if they are internal", () => {
         expect(typeOf("(the ID 5)", env, intEnv)).toBe("number");
+      });
+
+      it("should be compatible when defined as a record", () => {
+        expect(typeOf('(the Person {:name "david"})', env, intEnv)).toBe(
+          "{:name string}"
+        );
       });
     });
   });

--- a/packages/delisp-core/__tests__/unify.ts
+++ b/packages/delisp-core/__tests__/unify.ts
@@ -6,11 +6,7 @@ import {
   tVar,
   tVector
 } from "../src/types";
-import { unificationInEnvironment } from "../src/unify";
-
-const unify = unificationInEnvironment(name => {
-  throw new Error(`Unkonwn user defined type ${name}`);
-});
+import { unify } from "../src/unify";
 
 describe("Unification", () => {
   it("should perform an occur check", () => {
@@ -56,19 +52,19 @@ describe("Unification", () => {
     });
   });
 
-  describe("Type aliases", () => {
-    const unifyWithA = unificationInEnvironment(_name => {
-      return tNumber;
+  describe("User defined types", () => {
+    it("should unify with themselves", () => {
+      const t1 = tUserDefined("A");
+      const t2 = tUserDefined("A");
+      const result = unify(t1, t2, {});
+      expect(result.type).toBe("unify-success");
     });
 
-    it("should unify with its definition", () => {
+    it("should not unify with its definition", () => {
       const t1 = tNumber;
       const t2 = tUserDefined("A");
-      const result = unifyWithA(t1, t2, { a: tNumber });
-      expect(result.type).toBe("unify-success");
-      if (result.type === "unify-success") {
-        expect(result.substitution).toHaveProperty("a");
-      }
+      const result = unify(t1, t2, { a: tNumber });
+      expect(result.type).toBe("unify-mismatch-error");
     });
   });
 });

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -900,7 +900,7 @@ function groupAssumptions(
  *
  * @description Takes a Module and the external environment, will run
  * inference returning the same module with the types annotated in the
- * AST. Additionally, a set of unkonwn references is returned so those
+ * AST. Additionally, a set of unknown references is returned so those
  * can be reported.
  */
 export function inferModule(

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -41,6 +41,7 @@ import {
   tFn,
   tNumber,
   tRecord,
+  tRow,
   tString,
   tVar,
   tVector,
@@ -994,7 +995,7 @@ function expandTypeAliases(
     case "empty-row":
       return t;
     case "row-extension":
-      return tRecord(
+      return tRow(
         [{ label: t.label, type: expandTypeAliases(t.labelType, env) }],
         expandTypeAliases(t.extends, env)
       );

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -46,7 +46,7 @@ import {
   tVector,
   Type
 } from "./types";
-import { unificationInEnvironment } from "./unify";
+import { unify } from "./unify";
 import {
   difference,
   flatMap,
@@ -768,10 +768,6 @@ function solve(
   if (constraints.length === 0) {
     return solution;
   }
-
-  const unify = unificationInEnvironment(name => {
-    return typeEnvironment[name];
-  });
 
   // Check if a constraint is solvable.
   //

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -113,7 +113,7 @@ export interface SExport<I = {}> {
   location: Location;
 }
 
-export interface STypeAlias<_I> {
+export interface STypeAlias<_I = {}> {
   type: "type-alias";
   name: SVar;
   definition: Monotype;

--- a/packages/delisp-core/src/type-utils.ts
+++ b/packages/delisp-core/src/type-utils.ts
@@ -4,8 +4,37 @@ import { convert as convertType } from "./convert-type";
 import { readFromString } from "./reader";
 import { generateUniqueTVar } from "./type-generate";
 import { applySubstitution } from "./type-substitution";
-import { emptyRow, Monotype, TApplication, tVar, Type } from "./types";
+import {
+  emptyRow,
+  Monotype,
+  TApplication,
+  TUserDefined,
+  tVar,
+  Type
+} from "./types";
 import { flatMap, unique } from "./utils";
+
+// Return user defined types
+export function listUserDefinedReferences(t: Monotype): TUserDefined[] {
+  switch (t.type) {
+    case "void":
+    case "boolean":
+    case "string":
+    case "number":
+    case "empty-row":
+    case "type-variable":
+      return [];
+    case "user-defined-type":
+      return [t];
+    case "application":
+      return flatMap(listUserDefinedReferences, t.args);
+    case "row-extension":
+      return [
+        ...listUserDefinedReferences(t.labelType),
+        ...listUserDefinedReferences(t.extends)
+      ];
+  }
+}
 
 // Return the list of type variables in the order they show up
 export function listTypeVariables(t: Monotype): string[] {

--- a/packages/delisp-core/src/unify.ts
+++ b/packages/delisp-core/src/unify.ts
@@ -71,219 +71,224 @@ function occurCheck(v: TVar, rootT: Monotype): UnifyOccurCheckError | null {
   return check(rootT);
 }
 
-export function unificationInEnvironment(
-  lookupUserDefinedType: (name: string) => Monotype
-) {
-  //
-  //
-  function unifyVariable(v: TVar, t: Monotype, ctx: Substitution): UnifyResult {
-    if (v.name in ctx) {
-      return unify(ctx[v.name], t, ctx);
-    }
-    if (t.type === "type-variable") {
-      if (v.name === t.name) {
-        return success(ctx);
-      } else if (t.name in ctx) {
-        return unifyVariable(v, ctx[t.name], ctx);
-      } else {
-        return success({ ...ctx, [v.name]: t });
-      }
+//
+//
+function unifyVariable(v: TVar, t: Monotype, ctx: Substitution): UnifyResult {
+  if (v.name in ctx) {
+    return unify(ctx[v.name], t, ctx);
+  }
+  if (t.type === "type-variable") {
+    if (v.name === t.name) {
+      return success(ctx);
+    } else if (t.name in ctx) {
+      return unifyVariable(v, ctx[t.name], ctx);
     } else {
-      const err = occurCheck(v, t);
-      if (err) {
-        return err;
-      } else {
-        return success({ ...ctx, [v.name]: t });
-      }
+      return success({ ...ctx, [v.name]: t });
+    }
+  } else {
+    const err = occurCheck(v, t);
+    if (err) {
+      return err;
+    } else {
+      return success({ ...ctx, [v.name]: t });
     }
   }
+}
 
-  function unifyArray(
-    t1s: Monotype[],
-    t2s: Monotype[],
-    ctx: Substitution
-  ): UnifyResult {
-    if (t1s.length === 0 && t2s.length === 0) {
-      return success(ctx);
-    } else if (t1s.length === 0) {
+function unifyArray(
+  t1s: Monotype[],
+  t2s: Monotype[],
+  ctx: Substitution
+): UnifyResult {
+  if (t1s.length === 0 && t2s.length === 0) {
+    return success(ctx);
+  } else if (t1s.length === 0) {
+    return {
+      type: "unify-missing-value-error",
+      t: t2s[0]
+    };
+  } else if (t2s.length === 0) {
+    return {
+      type: "unify-missing-value-error",
+      t: t1s[0]
+    };
+  } else {
+    const [t1, ...rest1] = t1s;
+    const [t2, ...rest2] = t2s;
+    const result = unify(t1, t2, ctx);
+    if (result.type === "unify-success") {
+      return unifyArray(rest1, rest2, result.substitution);
+    } else {
+      return result;
+    }
+  }
+}
+
+/** Rewrite `row` to be a row staring with `label`.
+ *
+ * @returns an extension row, together with a subsitution that will
+ * partially unify it with `row` (only the head of the extension).
+ */
+function rewriteRowForLabel(
+  row: Monotype,
+  label: string,
+  ctx: Substitution
+): { row: RExtension; substitution: Substitution } {
+  if (row.type === "type-variable") {
+    // RULE (row-var)
+    //
+    // If `row` is a variable. We create a fresh row extension
+    //
+    //    {label: γ | β}
+    //
+    // and map that variable to the row in the substitution.
+    const gamma = generateUniqueTVar();
+    const beta = generateUniqueTVar();
+    const theta = tRowExtension(label, gamma, beta);
+    return {
+      row: theta,
+      substitution: { ...ctx, [row.name]: theta }
+    };
+  } else if (row.type === "row-extension") {
+    // RULE (row-head)
+    //
+    // If the `row` is already a row extension starting with the same
+    // label, we are done.
+    //
+    if (row.label === label) {
       return {
-        type: "unify-missing-value-error",
-        t: t2s[0]
-      };
-    } else if (t2s.length === 0) {
-      return {
-        type: "unify-missing-value-error",
-        t: t1s[0]
+        row,
+        substitution: ctx
       };
     } else {
-      const [t1, ...rest1] = t1s;
-      const [t2, ...rest2] = t2s;
-      const result = unify(t1, t2, ctx);
-      if (result.type === "unify-success") {
-        return unifyArray(rest1, rest2, result.substitution);
-      } else {
-        return result;
-      }
-    }
-  }
-
-  /** Rewrite `row` to be a row staring with `label`.
-   *
-   * @returns an extension row, together with a subsitution that will
-   * partially unify it with `row` (only the head of the extension).
-   */
-  function rewriteRowForLabel(
-    row: Monotype,
-    label: string,
-    ctx: Substitution
-  ): { row: RExtension; substitution: Substitution } {
-    if (row.type === "type-variable") {
-      // RULE (row-var)
+      // RULE (row-swap)
       //
-      // If `row` is a variable. We create a fresh row extension
-      //
-      //    {label: γ | β}
-      //
-      // and map that variable to the row in the substitution.
-      const gamma = generateUniqueTVar();
-      const beta = generateUniqueTVar();
-      const theta = tRowExtension(label, gamma, beta);
-      return {
-        row: theta,
-        substitution: { ...ctx, [row.name]: theta }
-      };
-    } else if (row.type === "row-extension") {
-      // RULE (row-head)
-      //
-      // If the `row` is already a row extension starting with the same
-      // label, we are done.
-      //
-      if (row.label === label) {
-        return {
-          row,
-          substitution: ctx
-        };
-      } else {
-        // RULE (row-swap)
-        //
-        // Firstly, we recursively rewrite the tail of the row extension
-        // to start with `label.`
-        const { row: newRow, substitution: subs } = rewriteRowForLabel(
-          row.extends,
-          label,
-          ctx
-        );
-        //
-        // The resulting row, starts with the intended label, and
-        // continues with the original label that we found.
-        return {
-          row: tRowExtension(
-            label,
-            newRow.labelType,
-            tRowExtension(row.label, row.labelType, newRow.extends)
-          ),
-          substitution: subs
-        };
-      }
-    } else {
-      throw new Error("Should not get here");
-    }
-  }
-
-  function unifyRow(
-    row1: RExtension,
-    row2: RExtension,
-    ctx: Substitution
-  ): UnifyResult {
-    const { substitution: subs, row: row3 } = rewriteRowForLabel(
-      row2,
-      row1.label,
-      ctx
-    );
-
-    if (row1.extends.type === "type-variable" && subs[row1.extends.name]) {
-      return {
-        type: "unify-mismatch-error",
-        t1: row1,
-        t2: row2
-      };
-    }
-
-    return unifyArray(
-      [row1.labelType, row1.extends],
-      [row3.labelType, row3.extends],
-      subs
-    );
-  }
-
-  /** Compute the the most general unifier that unifies t1 and t2.
-   *
-   * @description The resulting subsitution, applied with
-   * `applySubstitution` to t1 and t2 will make them equal. It is also
-   * the most general one, in the sense that any other substitution can
-   * be obtained as a composition of this one with another one.
-   */
-  function unify(t1: Monotype, t2: Monotype, ctx: Substitution): UnifyResult {
-    // RULE (uni-const)
-    if (t1.type === "string" && t2.type === "string") {
-      return success(ctx);
-    } else if (t1.type === "number" && t2.type === "number") {
-      return success(ctx);
-    } else if (t1.type === "boolean" && t2.type === "boolean") {
-      return success(ctx);
-    } else if (
-      t1.type === "type-variable" &&
-      t1.userSpecified &&
-      t2.type === "type-variable" &&
-      t2.userSpecified
-    ) {
-      return t1 === t2
-        ? success(ctx)
-        : {
-            type: "unify-mismatch-error",
-            t1,
-            t2
-          };
-    } else if (
-      t1.type === "application" &&
-      t2.type === "application" &&
-      t1.op === t2.op
-    ) {
-      // RULE: (uni-app)
-      const argResult = unifyArray(
-        t1.args.slice(0, t1.args.length - 1),
-        t2.args.slice(0, t2.args.length - 1),
+      // Firstly, we recursively rewrite the tail of the row extension
+      // to start with `label.`
+      const { row: newRow, substitution: subs } = rewriteRowForLabel(
+        row.extends,
+        label,
         ctx
       );
-      if (argResult.type === "unify-success") {
-        return unify(last(t1.args)!, last(t2.args)!, argResult.substitution);
-      } else {
-        return argResult;
-      }
-    } else if (t1.type === "type-variable" && !t1.userSpecified) {
-      // RULE: (uni-varl)
-      return unifyVariable(t1, t2, ctx);
-    } else if (t2.type === "type-variable" && !t2.userSpecified) {
-      // RULE: (uni-varr)
-      return unifyVariable(t2, t1, ctx);
-    } else if (t1.type === "user-defined-type") {
-      return unify(lookupUserDefinedType(t1.name), t2, ctx);
-    } else if (t2.type === "user-defined-type") {
-      return unify(t1, lookupUserDefinedType(t2.name), ctx);
-    } else if (t1.type === "empty-row" && t2.type === "empty-row") {
-      // RULE (uni-const)
-      return success(ctx);
-    } else if (t1.type === "row-extension" && t2.type === "row-extension") {
-      // RULE: (uni-row)
-      return unifyRow(t1, t2, ctx);
-    } else {
+      //
+      // The resulting row, starts with the intended label, and
+      // continues with the original label that we found.
       return {
-        type: "unify-mismatch-error",
-        t1,
-        t2
+        row: tRowExtension(
+          label,
+          newRow.labelType,
+          tRowExtension(row.label, row.labelType, newRow.extends)
+        ),
+        substitution: subs
       };
     }
+  } else {
+    throw new Error("Should not get here");
+  }
+}
+
+function unifyRow(
+  row1: RExtension,
+  row2: RExtension,
+  ctx: Substitution
+): UnifyResult {
+  const { substitution: subs, row: row3 } = rewriteRowForLabel(
+    row2,
+    row1.label,
+    ctx
+  );
+
+  if (row1.extends.type === "type-variable" && subs[row1.extends.name]) {
+    return {
+      type: "unify-mismatch-error",
+      t1: row1,
+      t2: row2
+    };
   }
 
-  return unify;
+  return unifyArray(
+    [row1.labelType, row1.extends],
+    [row3.labelType, row3.extends],
+    subs
+  );
+}
+
+/** Compute the the most general unifier that unifies t1 and t2.
+ *
+ * @description The resulting subsitution, applied with
+ * `applySubstitution` to t1 and t2 will make them equal. It is also
+ * the most general one, in the sense that any other substitution can
+ * be obtained as a composition of this one with another one.
+ */
+export function unify(
+  t1: Monotype,
+  t2: Monotype,
+  ctx: Substitution
+): UnifyResult {
+  // RULE (uni-const)
+  if (t1.type === "string" && t2.type === "string") {
+    return success(ctx);
+  } else if (t1.type === "number" && t2.type === "number") {
+    return success(ctx);
+  } else if (t1.type === "boolean" && t2.type === "boolean") {
+    return success(ctx);
+  } else if (
+    t1.type === "user-defined-type" &&
+    t2.type === "user-defined-type"
+  ) {
+    return t1.name === t2.name
+      ? success(ctx)
+      : {
+          type: "unify-mismatch-error",
+          t1,
+          t2
+        };
+  } else if (
+    t1.type === "type-variable" &&
+    t1.userSpecified &&
+    t2.type === "type-variable" &&
+    t2.userSpecified
+  ) {
+    return t1 === t2
+      ? success(ctx)
+      : {
+          type: "unify-mismatch-error",
+          t1,
+          t2
+        };
+  } else if (
+    t1.type === "application" &&
+    t2.type === "application" &&
+    t1.op === t2.op
+  ) {
+    // RULE: (uni-app)
+    const argResult = unifyArray(
+      t1.args.slice(0, t1.args.length - 1),
+      t2.args.slice(0, t2.args.length - 1),
+      ctx
+    );
+    if (argResult.type === "unify-success") {
+      return unify(last(t1.args)!, last(t2.args)!, argResult.substitution);
+    } else {
+      return argResult;
+    }
+  } else if (t1.type === "type-variable" && !t1.userSpecified) {
+    // RULE: (uni-varl)
+    return unifyVariable(t1, t2, ctx);
+  } else if (t2.type === "type-variable" && !t2.userSpecified) {
+    // RULE: (uni-varr)
+    return unifyVariable(t2, t1, ctx);
+  } else if (t1.type === "empty-row" && t2.type === "empty-row") {
+    // RULE (uni-const)
+    return success(ctx);
+  } else if (t1.type === "row-extension" && t2.type === "row-extension") {
+    // RULE: (uni-row)
+    return unifyRow(t1, t2, ctx);
+  } else {
+    return {
+      type: "unify-mismatch-error",
+      t1,
+      t2
+    };
+  }
 }


### PR DESCRIPTION
Implement expansion of internal (defined in the module) type aliases before unification.

Unknown type aliases, like those returned by other modules, they are considered user-defined proper types , instead of aliases, so they only unify with themselves.

That means:
`(the ID number)`

works locally in the same module as a number. But if you export a function
`(define make-id (lambda (x) (the ID x)))`

then the returned ID will be considered a blackbox type by other modules. So that is a smart constructor.