### PR TITLE
Pretty print type annotations including wildcards

### DIFF
--- a/packages/delisp-core/__tests__/printer.ts
+++ b/packages/delisp-core/__tests__/printer.ts
@@ -53,7 +53,7 @@ eee
     );
   });
 
-  it.skip("should retain partial type annotations", () => {
+  it("should retain partial type annotations", () => {
     prettySimilar(
       `(the (-> string number _) (lambda (name age) {:name name :age age}))`
     );

--- a/packages/delisp-core/src/convert-type.ts
+++ b/packages/delisp-core/src/convert-type.ts
@@ -8,7 +8,7 @@ import {
   ASExprSymbol,
   ASExprVector
 } from "./sexpr";
-import { generateUniqueTVar } from "./type-generate";
+
 import {
   emptyRow,
   Monotype,
@@ -54,8 +54,6 @@ function convertSymbol(expr: ASExprSymbol): Monotype {
       return tString;
     case "void":
       return tVoid;
-    case "_":
-      return generateUniqueTVar(false, "__t");
     default:
       return userDefinedType(expr) ? tUserDefined(expr.name) : tVar(expr.name);
   }

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -21,7 +21,7 @@ import {
   convert as convertType
 } from "./convert-type";
 import { parseRecord } from "./convert-utils";
-import { generalize, listTypeVariables } from "./type-utils";
+import { listTypeVariables } from "./type-utils";
 
 const conversions: Map<string, (expr: ASExprList) => Expression> = new Map();
 const toplevelConversions: Map<
@@ -215,7 +215,9 @@ defineConversion("the", expr => {
 
   return {
     type: "type-annotation",
-    valueType: generalize(convertType(t), []),
+    valueType: {
+      typeWithWildcards: convertType(t)
+    },
     value: convertExpr(value),
     location: expr.location,
     info: {}

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -22,6 +22,7 @@ import {
 } from "./convert-type";
 import { parseRecord } from "./convert-utils";
 import { listTypeVariables } from "./type-utils";
+import { TypeWithWildcards } from "./type-wildcards";
 
 const conversions: Map<string, (expr: ASExprList) => Expression> = new Map();
 const toplevelConversions: Map<
@@ -215,9 +216,7 @@ defineConversion("the", expr => {
 
   return {
     type: "type-annotation",
-    valueType: {
-      typeWithWildcards: convertType(t)
-    },
+    valueType: new TypeWithWildcards(convertType(t)),
     value: convertExpr(value),
     location: expr.location,
     info: {}

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -21,7 +21,7 @@ import {
   Typed
 } from "./syntax";
 
-import { transformRecurExpr, instantiateTypeAnnotation } from "./syntax-utils";
+import { transformRecurExpr } from "./syntax-utils";
 
 import { applySubstitution, Substitution } from "./type-utils";
 import { printType } from "./type-printer";
@@ -433,10 +433,7 @@ function infer(
 
     case "type-annotation": {
       const inferred = infer(expr.value, monovars, internalTypes);
-      const t = expandTypeAliases(
-        instantiateTypeAnnotation(expr),
-        internalTypes
-      );
+      const t = expandTypeAliases(expr.valueType.instantiate(), internalTypes);
 
       return {
         result: {

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -21,7 +21,7 @@ import {
   Typed
 } from "./syntax";
 
-import { transformRecurExpr } from "./syntax-utils";
+import { transformRecurExpr, instantiateTypeAnnotation } from "./syntax-utils";
 
 import { applySubstitution, Substitution } from "./type-utils";
 import { printType } from "./type-printer";
@@ -434,7 +434,7 @@ function infer(
     case "type-annotation": {
       const inferred = infer(expr.value, monovars, internalTypes);
       const t = expandTypeAliases(
-        instantiate(expr.valueType, true),
+        instantiateTypeAnnotation(expr),
         internalTypes
       );
 

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -139,7 +139,7 @@ function print(sexpr: Syntax): Doc {
         list(
           text("the"),
           space,
-          text(printType(sexpr.valueType.mono, false)),
+          text(printType(sexpr.valueType.typeWithWildcards, false)),
           indent(concat(line, print(sexpr.value)))
         )
       );

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -139,7 +139,7 @@ function print(sexpr: Syntax): Doc {
         list(
           text("the"),
           space,
-          text(printType(sexpr.valueType.typeWithWildcards, false)),
+          text(sexpr.valueType.print()),
           indent(concat(line, print(sexpr.value)))
         )
       );

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -1,9 +1,5 @@
 import { InvariantViolation } from "./invariant";
-import { Expression, Module, STypeAnnotation, Syntax } from "./syntax";
-
-import { Monotype } from "./types";
-import { transformRecurType, generalize, instantiate } from "./type-utils";
-import { generateUniqueTVar } from "./type-generate";
+import { Expression, Module, Syntax } from "./syntax";
 
 export function transformRecurExpr<I>(
   s: Expression<I>,
@@ -134,16 +130,4 @@ export function findSyntaxByOffset<I>(
   offset: number
 ): Syntax<I> | undefined {
   return findSyntaxByRange(m, offset, offset);
-}
-
-export function instantiateTypeAnnotation(t: STypeAnnotation): Monotype {
-  const nowildcards = transformRecurType(t.valueType.typeWithWildcards, t1 => {
-    if (t1.type === "type-variable" && t1.name === "_") {
-      return generateUniqueTVar(false, "__t");
-    } else {
-      return t1;
-    }
-  });
-  const typ = generalize(nowildcards, []);
-  return instantiate(typ, true);
 }

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -1,5 +1,9 @@
 import { InvariantViolation } from "./invariant";
-import { Expression, Module, Syntax } from "./syntax";
+import { Expression, Module, STypeAnnotation, Syntax } from "./syntax";
+
+import { Monotype } from "./types";
+import { transformRecurType, generalize, instantiate } from "./type-utils";
+import { generateUniqueTVar } from "./type-generate";
 
 export function transformRecurExpr<I>(
   s: Expression<I>,
@@ -130,4 +134,16 @@ export function findSyntaxByOffset<I>(
   offset: number
 ): Syntax<I> | undefined {
   return findSyntaxByRange(m, offset, offset);
+}
+
+export function instantiateTypeAnnotation(t: STypeAnnotation): Monotype {
+  const nowildcards = transformRecurType(t.valueType.typeWithWildcards, t1 => {
+    if (t1.type === "type-variable" && t1.name === "_") {
+      return generateUniqueTVar(false, "__t");
+    } else {
+      return t1;
+    }
+  });
+  const typ = generalize(nowildcards, []);
+  return instantiate(typ, true);
 }

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -1,5 +1,6 @@
 import { Location } from "./input";
 import { Monotype } from "./types";
+import { TypeWithWildcards } from "./type-wildcards";
 
 //
 // Expressions
@@ -81,9 +82,7 @@ export interface SRecord<I = {}> extends Node<I> {
 export interface STypeAnnotation<I = {}> extends Node<I> {
   type: "type-annotation";
   value: Expression<I>;
-  valueType: {
-    typeWithWildcards: Monotype;
-  };
+  valueType: TypeWithWildcards;
 }
 
 export type Expression<I = {}> =

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -1,5 +1,5 @@
 import { Location } from "./input";
-import { Monotype, Type } from "./types";
+import { Monotype } from "./types";
 
 //
 // Expressions
@@ -81,7 +81,9 @@ export interface SRecord<I = {}> extends Node<I> {
 export interface STypeAnnotation<I = {}> extends Node<I> {
   type: "type-annotation";
   value: Expression<I>;
-  valueType: Type;
+  valueType: {
+    typeWithWildcards: Monotype;
+  };
 }
 
 export type Expression<I = {}> =

--- a/packages/delisp-core/src/type-wildcards.ts
+++ b/packages/delisp-core/src/type-wildcards.ts
@@ -1,0 +1,47 @@
+import { Monotype, Type } from "./types";
+import { generalize, instantiate, transformRecurType } from "./type-utils";
+import { generateUniqueTVar } from "./type-generate";
+import { printType } from "./type-printer";
+
+/** A template for a type, but it can contain the wildcard _
+ *
+ * @description
+ *
+ * Note this is not just a type, because it can't be genralized. For
+ * instance,
+ *
+ * (-> _ _)
+ *
+ * The variable `_` can take different types. So when generalized, it
+ * will return a type like
+ *
+ * (-> __t1 __t2)
+ *
+ * which can be then instantiated.
+ *
+ **/
+export class TypeWithWildcards {
+  private body: Monotype;
+  constructor(body: Monotype) {
+    this.body = body;
+  }
+
+  generalize(): Type {
+    const nowildcards = transformRecurType(this.body, t1 => {
+      if (t1.type === "type-variable" && t1.name === "_") {
+        return generateUniqueTVar(false, "__t");
+      } else {
+        return t1;
+      }
+    });
+    return generalize(nowildcards, []);
+  }
+
+  instantiate(): Monotype {
+    return instantiate(this.generalize(), true);
+  }
+
+  print(): string {
+    return printType(this.body, false);
+  }
+}


### PR DESCRIPTION
Ensure the type wildcards are expanded during type inference of type annotations, not during conversion.

This fixes #68 
