### PR TITLE
Add Identifier to syntax

### DIFF
--- a/packages/delisp-core/__tests__/read-module.ts
+++ b/packages/delisp-core/__tests__/read-module.ts
@@ -8,7 +8,7 @@ describe("ReadModule", () => {
         {
           tag: "function-call",
           fn: {
-            tag: "variable-reference",
+            tag: "identifier",
             name: "sum"
           },
           args: [
@@ -20,7 +20,7 @@ describe("ReadModule", () => {
         {
           tag: "function-call",
           fn: {
-            tag: "variable-reference",
+            tag: "identifier",
             name: "+"
           },
           args: [{ tag: "number", value: 4 }, { tag: "number", value: 5 }]
@@ -28,7 +28,7 @@ describe("ReadModule", () => {
         {
           tag: "function-call",
           fn: {
-            tag: "variable-reference",
+            tag: "identifier",
             name: "inc"
           },
           args: [{ tag: "number", value: 6 }]

--- a/packages/delisp-core/__tests__/syntax-locator.ts
+++ b/packages/delisp-core/__tests__/syntax-locator.ts
@@ -25,9 +25,9 @@ describe("findSyntaxByOffset", () => {
     expect(s.tag.name).toBe("abcdef");
   });
 
-  it("should give the right location in a variable reference", () => {
+  it("should give the right location in an identifier", () => {
     const s = cursorAt(`(define x a_|_ms)`) as any;
-    expect(s.tag).toBe("variable-reference");
+    expect(s.tag).toBe("identifier");
     expect(s.name).toBe("ams");
   });
 

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -10,9 +10,9 @@ import {
   SExport,
   SFunction,
   SFunctionCall,
+  SIdentifier,
   SLet,
   SRecord,
-  SVariableReference,
   SVectorConstructor,
   Syntax
 } from "./syntax";
@@ -143,10 +143,7 @@ function compileFunctionCall(
   env: Environment
 ): JS.Expression {
   const compiledArgs = funcall.args.map(arg => compile(arg, env));
-  if (
-    funcall.fn.tag === "variable-reference" &&
-    isInlinePrimitive(funcall.fn.name)
-  ) {
+  if (funcall.fn.tag === "identifier" && isInlinePrimitive(funcall.fn.name)) {
     return compileInlinePrimitive(funcall.fn.name, compiledArgs, "funcall");
   } else {
     return {
@@ -157,10 +154,7 @@ function compileFunctionCall(
   }
 }
 
-function compileVariable(
-  ref: SVariableReference,
-  env: Environment
-): JS.Expression {
+function compileIdentifier(ref: SIdentifier, env: Environment): JS.Expression {
   const binding = lookupBinding(ref.name, env);
 
   if (!binding) {
@@ -309,8 +303,8 @@ export function compile(expr: Expression, env: Environment): JS.Expression {
       return compileVector(expr, env);
     case "record":
       return compileRecord(expr, env);
-    case "variable-reference":
-      return compileVariable(expr, env);
+    case "identifier":
+      return compileIdentifier(expr, env);
     case "conditional":
       return compileConditional(expr, env);
     case "function":

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -107,14 +107,14 @@ function compileLambda(
   env: Environment
 ): JS.ArrowFunctionExpression {
   const newEnv = fn.lambdaList.positionalArgs.reduce(
-    (e, param) => addBinding(param.variable, e),
+    (e, param) => addBinding(param.name, e),
     env
   );
 
   const jsargs = fn.lambdaList.positionalArgs.map(
     (param): JS.Pattern => ({
       type: "Identifier",
-      name: lookupBinding(param.variable, newEnv).jsname
+      name: lookupBinding(param.name, newEnv).jsname
     })
   );
 

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -134,7 +134,7 @@ function compileLambda(
 
 function compileDefinition(def: SDefinition, env: Environment): JS.Statement {
   const value = compile(def.value, env);
-  const name = lookupBinding(def.variable, env).jsname;
+  const name = lookupBinding(def.variable.name, env).jsname;
   return env.defs.define(name, value);
 }
 
@@ -388,7 +388,7 @@ export function moduleEnvironment(
 ): Environment {
   const moduleDefinitions = m.body
     .filter(isDefinition)
-    .map(decl => decl.variable);
+    .map(decl => decl.variable.name);
   const moduleBindings = moduleDefinitions.reduce(
     (d, decl) => ({
       ...d,

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -251,11 +251,11 @@ function compileRecord(expr: SRecord, env: Environment): JS.Expression {
     type: "ObjectExpression",
     properties: expr.fields.map(
       ({ label, value }): JS.Property => {
-        if (!label.startsWith(":")) {
+        if (!label.name.startsWith(":")) {
           throw new InvariantViolation(`Invalid record ${label}`);
         }
 
-        const name = label.replace(/^:/, "");
+        const name = label.name.replace(/^:/, "");
 
         return {
           type: "Property",

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -202,7 +202,7 @@ function compileConditional(
 
 function compileLetBindings(expr: SLet, env: Environment): JS.Expression {
   const newenv = expr.bindings.reduce(
-    (e, binding) => addBinding(binding.var, e),
+    (e, binding) => addBinding(binding.variable.name, e),
     env
   );
 
@@ -213,7 +213,7 @@ function compileLetBindings(expr: SLet, env: Environment): JS.Expression {
       params: expr.bindings.map(
         (b): JS.Pattern => ({
           type: "Identifier",
-          name: lookupBinding(b.var, newenv).jsname
+          name: lookupBinding(b.variable.name, newenv).jsname
         })
       ),
       body: compileBody(expr.body, newenv)

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -320,7 +320,7 @@ defineToplevel("type", expr => {
 
   return {
     tag: "type-alias",
-    name: name.name,
+    alias: parseIdentifier(name),
     definition: definitionType,
     location: expr.location
   };

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -10,8 +10,8 @@ import {
   Declaration,
   Expression,
   LambdaList,
+  SIdentifier,
   SLetBinding,
-  SVariableReference,
   Syntax
 } from "./syntax";
 import { last } from "./utils";
@@ -372,9 +372,9 @@ function convertMap(map: ASExprMap): Expression {
   };
 }
 
-function convertSymbol(expr: ASExprSymbol): SVariableReference {
+function convertSymbol(expr: ASExprSymbol): SIdentifier {
   return {
-    tag: "variable-reference",
+    tag: "identifier",
     name: expr.name,
     location: expr.location,
     info: {}

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -358,8 +358,7 @@ function convertMap(map: ASExprMap): Expression {
   return {
     tag: "record",
     fields: fields.map(f => ({
-      label: f.label.name,
-      labelLocation: f.label.location,
+      label: convertSymbol(f.label),
       value: convertExpr(f.value)
     })),
     extends: tail && convertExpr(tail),

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -51,15 +51,6 @@ function parseBody(anchor: ASExpr, exprs: ASExpr[]): Expression[] {
 // The format of lambda lists are (a b c ... &rest z)
 //
 
-function parseIdentifier(s: ASExprSymbol): SIdentifier {
-  return {
-    tag: "identifier",
-    name: s.name,
-    location: s.location,
-    info: {}
-  };
-}
-
 function parseLambdaList(ll: ASExpr): LambdaList {
   if (ll.tag !== "list") {
     throw new Error(
@@ -94,7 +85,7 @@ function parseLambdaList(ll: ASExpr): LambdaList {
   });
 
   return {
-    positionalArgs: symbols.map(parseIdentifier),
+    positionalArgs: symbols.map(convertSymbol),
     location: ll.location
   };
 }
@@ -154,7 +145,7 @@ function parseLetBindings(bindings: ASExpr): SLetBinding[] {
   }
 
   return bindings.fields.map(field => ({
-    variable: parseIdentifier(field.label),
+    variable: convertSymbol(field.label),
     value: convertExpr(field.value)
   }));
 }
@@ -252,7 +243,7 @@ defineToplevel("define", expr => {
 
   return {
     tag: "definition",
-    variable: parseIdentifier(variable),
+    variable: convertSymbol(variable),
     value: convertExpr(value),
     location: expr.location
   };
@@ -320,7 +311,7 @@ defineToplevel("type", expr => {
 
   return {
     tag: "type-alias",
-    alias: parseIdentifier(name),
+    alias: convertSymbol(name),
     definition: definitionType,
     location: expr.location
   };

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -51,6 +51,15 @@ function parseBody(anchor: ASExpr, exprs: ASExpr[]): Expression[] {
 // The format of lambda lists are (a b c ... &rest z)
 //
 
+function parseIdentifier(s: ASExprSymbol): SIdentifier {
+  return {
+    tag: "identifier",
+    name: s.name,
+    location: s.location,
+    info: {}
+  };
+}
+
 function parseLambdaList(ll: ASExpr): LambdaList {
   if (ll.tag !== "list") {
     throw new Error(
@@ -85,10 +94,7 @@ function parseLambdaList(ll: ASExpr): LambdaList {
   });
 
   return {
-    positionalArgs: symbols.map(arg => ({
-      variable: arg.name,
-      location: arg.location
-    })),
+    positionalArgs: symbols.map(parseIdentifier),
     location: ll.location
   };
 }

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -252,7 +252,7 @@ defineToplevel("define", expr => {
 
   return {
     tag: "definition",
-    variable: variable.name,
+    variable: parseIdentifier(variable),
     value: convertExpr(value),
     location: expr.location
   };

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -154,9 +154,8 @@ function parseLetBindings(bindings: ASExpr): SLetBinding[] {
   }
 
   return bindings.fields.map(field => ({
-    var: field.label.name,
-    value: convertExpr(field.value),
-    location: field.label.location
+    variable: parseIdentifier(field.label),
+    value: convertExpr(field.value)
   }));
 }
 

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -15,8 +15,8 @@ import {
   Expression,
   isTypeAlias,
   Module,
+  SIdentifier,
   STypeAlias,
-  SVariableReference,
   Syntax,
   Typed
 } from "./syntax";
@@ -81,7 +81,7 @@ import primitives from "./primitives";
 // is normal to have multiple assumptions (instances) for the same
 // variable. Assumptions will be converted to additional constraints
 // at the end of the inference process.
-type TAssumption = SVariableReference<Typed>;
+type TAssumption = SIdentifier<Typed>;
 
 // Constraints impose which types should be equal (unified) and which
 // types are instances of other types.
@@ -259,7 +259,7 @@ function infer(
         ]
       };
     }
-    case "variable-reference": {
+    case "identifier": {
       // as we found a variable, and because we lack an
       // 'environment/context', we generate a new type and add an
       // assumption for this variable.
@@ -481,7 +481,7 @@ function inferSyntax(
     return {
       result: {
         ...syntax,
-        value: result as SVariableReference<Typed>
+        value: result as SIdentifier<Typed>
       },
       assumptions,
       constraints
@@ -676,7 +676,7 @@ function applySubstitutionToSyntax(
   } else if (s.tag === "export") {
     return {
       ...s,
-      value: applySubstitutionToExpr(s.value, env) as SVariableReference<Typed>
+      value: applySubstitutionToExpr(s.value, env) as SIdentifier<Typed>
     };
   } else if (s.tag === "type-alias") {
     return s;
@@ -972,9 +972,7 @@ export function inferModule(
     },
     unknowns: assumptions.unknowns.map(
       (v): TAssumption => {
-        return applySubstitutionToExpr(v, solution) as SVariableReference<
-          Typed
-        >;
+        return applySubstitutionToExpr(v, solution) as SIdentifier<Typed>;
       }
     )
   };

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -940,7 +940,7 @@ export function inferModule(
   const internalEnv: InternalEnvironment = {
     variables: body.reduce((env, s) => {
       if (s.tag === "definition") {
-        return { ...env, [s.variable]: s.value.info.type };
+        return { ...env, [s.variable.name]: s.value.info.type };
       } else {
         return env;
       }

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -866,7 +866,7 @@ function checkCircularTypes(allTypeAliases: STypeAlias[]) {
     if (index < 0) {
       listTypeConstants(typeAlias.definition)
         .map(ud => {
-          return allTypeAliases.find(x => x.name === ud.name);
+          return allTypeAliases.find(x => x.alias.name === ud.name);
         })
         .forEach(dep => {
           if (!dep) {
@@ -889,7 +889,7 @@ function checkCircularTypes(allTypeAliases: STypeAlias[]) {
         throw new Error(
           printHighlightedExpr(
             `Cicular dependency in type aliases found
-  ${cycle.map(s => s.name).join(" -> ")}
+  ${cycle.map(s => s.alias.name).join(" -> ")}
 `,
             typeAlias.location
           )
@@ -928,7 +928,7 @@ export function inferModule(
   checkCircularTypes(m.body.filter(isTypeAlias));
   const internalTypes: InternalTypeEnvironment = m.body.reduce((env, s) => {
     if (s.tag === "type-alias") {
-      return { ...env, [s.name]: s.definition };
+      return { ...env, [s.alias.name]: s.definition };
     } else {
       return env;
     }

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -308,7 +308,7 @@ function infer(
       };
     }
     case "function": {
-      const fnargs = expr.lambdaList.positionalArgs.map(a => a.variable);
+      const fnargs = expr.lambdaList.positionalArgs.map(a => a.name);
       const argtypes = fnargs.map(_ => generateUniqueTVar());
 
       const { result: typedBody, constraints, assumptions } = inferMany(

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -209,9 +209,8 @@ function infer(
     }
 
     case "record": {
-      const inferred = expr.fields.map(({ label, labelLocation, value }) => ({
+      const inferred = expr.fields.map(({ label, value }) => ({
         label,
-        labelLocation,
         ...infer(value, monovars, internalTypes)
       }));
 
@@ -222,15 +221,17 @@ function infer(
       return {
         result: {
           ...expr,
-          fields: inferred.map(({ label, labelLocation, result: value }) => ({
+          fields: inferred.map(({ label, result: value }) => ({
             label,
-            labelLocation,
             value
           })),
           extends: tailInferred && tailInferred.result,
           info: {
             type: tRecord(
-              inferred.map(i => ({ label: i.label, type: i.result.info.type })),
+              inferred.map(i => ({
+                label: i.label.name,
+                type: i.result.info.type
+              })),
               tailInferred ? tailRowType : emptyRow
             )
           }
@@ -248,7 +249,7 @@ function infer(
                   tailInferred.result,
                   tRecord(
                     inferred.map(i => ({
-                      label: i.label,
+                      label: i.label.name,
                       type: generateUniqueTVar()
                     })),
                     tailRowType

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -383,7 +383,7 @@ function infer(
       //
 
       // Variables showing up in the bindings
-      const vars = new Set(expr.bindings.map(b => b.var));
+      const vars = new Set(expr.bindings.map(b => b.variable.name));
       const toBeBound = (vname: string) => vars.has(vname);
 
       const bindingsInfo = expr.bindings.map(b => {
@@ -418,7 +418,9 @@ function infer(
             .map(v => {
               // We just filter the assumptions to the variables
               // that are bound, so we know it must is defined.
-              const bInfo = bindingsInfo.find(bi => bi.binding.var === v.name)!;
+              const bInfo = bindingsInfo.find(
+                bi => bi.binding.variable.name === v.name
+              )!;
               return constImplicitInstance(
                 v,
                 monovars,

--- a/packages/delisp-core/src/module.ts
+++ b/packages/delisp-core/src/module.ts
@@ -36,7 +36,7 @@ export function removeModuleTypeDefinition(m: Module, name: string): Module {
   return {
     tag: "module",
     body: m.body.filter(d => {
-      return d.tag === "type-alias" ? d.name !== name : true;
+      return d.tag === "type-alias" ? d.alias.name !== name : true;
     })
   };
 }

--- a/packages/delisp-core/src/module.ts
+++ b/packages/delisp-core/src/module.ts
@@ -27,7 +27,7 @@ export function removeModuleDefinition(m: Module, name: string): Module {
   return {
     tag: "module",
     body: m.body.filter(d => {
-      return d.tag === "definition" ? d.variable !== name : true;
+      return d.tag === "definition" ? d.variable.name !== name : true;
     })
   };
 }

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -153,7 +153,7 @@ function print(sexpr: Syntax): Doc {
         list(
           text("type"),
           space,
-          text(sexpr.name),
+          text(sexpr.alias.name),
           indent(concat(line, text(printType(sexpr.definition, false))))
         )
       );

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -91,7 +91,7 @@ function print(sexpr: Syntax): Doc {
       );
 
     case "function":
-      const argNames = sexpr.lambdaList.positionalArgs.map(x => x.variable);
+      const argNames = sexpr.lambdaList.positionalArgs.map(x => x.name);
       const singleBody = sexpr.body.length === 1;
       const doc = list(
         text("lambda"),

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -59,8 +59,8 @@ function print(sexpr: Syntax): Doc {
         map(
           align(
             join(
-              sexpr.fields.map(({ label: k, value: v }) =>
-                concat(text(k), space, print(v))
+              sexpr.fields.map(({ label, value }) =>
+                concat(text(label.name), space, print(value))
               ),
               line
             )

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -116,7 +116,7 @@ function print(sexpr: Syntax): Doc {
         list(
           text("define"),
           space,
-          printIdentifier(sexpr.variable),
+          printIdentifier(sexpr.variable.name),
           indent(concat(line, print(sexpr.value)))
         )
       );

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -131,7 +131,7 @@ function print(sexpr: Syntax): Doc {
         map(
           align(
             ...sexpr.bindings.map(b =>
-              concat(text(b.var), space, print(b.value))
+              concat(text(b.variable.name), space, print(b.value))
             )
           )
         ),

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -24,7 +24,7 @@ function printString(str: string): Doc {
   return text(`"${escaped}"`);
 }
 
-function printVariable(name: string): Doc {
+function printIdentifier(name: string): Doc {
   return text(name);
 }
 
@@ -68,8 +68,8 @@ function print(sexpr: Syntax): Doc {
         )
       );
     }
-    case "variable-reference":
-      return printVariable(sexpr.name);
+    case "identifier":
+      return printIdentifier(sexpr.name);
 
     case "conditional":
       return group(
@@ -96,7 +96,7 @@ function print(sexpr: Syntax): Doc {
       const doc = list(
         text("lambda"),
         space,
-        group(list(align(...argNames.map(printVariable)))),
+        group(list(align(...argNames.map(printIdentifier)))),
         indent(printBody(sexpr.body))
       );
       return singleBody ? group(doc) : doc;
@@ -116,7 +116,7 @@ function print(sexpr: Syntax): Doc {
         list(
           text("define"),
           space,
-          printVariable(sexpr.variable),
+          printIdentifier(sexpr.variable),
           indent(concat(line, print(sexpr.value)))
         )
       );

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -8,7 +8,7 @@ export function transformRecurExpr<I>(
   switch (s.tag) {
     case "string":
     case "number":
-    case "variable-reference":
+    case "identifier":
       return fn(s);
     case "vector":
       return fn({
@@ -62,7 +62,7 @@ function expressionChildren<I>(e: Expression<I>): Array<Expression<I>> {
   switch (e.tag) {
     case "string":
     case "number":
-    case "variable-reference":
+    case "identifier":
       return [];
     case "conditional":
       return [e.condition, e.consequent, e.alternative];

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -102,7 +102,7 @@ export type Expression<I = {}> =
 
 export interface SDefinition<I = {}> {
   tag: "definition";
-  variable: SVar;
+  variable: SIdentifier;
   value: Expression<I>;
   location: Location;
 }

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -42,7 +42,7 @@ export interface SFunctionCall<I = {}> extends Node<I> {
 }
 
 export interface LambdaList {
-  positionalArgs: Array<{ variable: SVar; location: Location }>;
+  positionalArgs: SIdentifier[];
   location: Location;
 }
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -70,8 +70,7 @@ export interface SLet<I = {}> extends Node<I> {
 export interface SRecord<I = {}> extends Node<I> {
   tag: "record";
   fields: Array<{
-    label: string;
-    labelLocation: Location;
+    label: SIdentifier;
     value: Expression<I>;
   }>;
   extends?: Expression<I>;

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -115,7 +115,7 @@ export interface SExport<I = {}> {
 
 export interface STypeAlias<_I = {}> {
   tag: "type-alias";
-  name: SVar;
+  alias: SIdentifier;
   definition: Type;
   location: Location;
 }

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -58,9 +58,8 @@ export interface SVectorConstructor<I = {}> extends Node<I> {
 }
 
 export interface SLetBinding<I = {}> {
-  var: SVar;
+  variable: SIdentifier;
   value: Expression<I>;
-  location: Location;
 }
 
 export interface SLet<I = {}> extends Node<I> {

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -23,8 +23,8 @@ export interface SString<I = {}> extends Node<I> {
   value: string;
 }
 
-export interface SVariableReference<I = {}> extends Node<I> {
-  tag: "variable-reference";
+export interface SIdentifier<I = {}> extends Node<I> {
+  tag: "identifier";
   name: SVar;
 }
 
@@ -88,7 +88,7 @@ export interface STypeAnnotation<I = {}> extends Node<I> {
 export type Expression<I = {}> =
   | SNumber<I>
   | SString<I>
-  | SVariableReference<I>
+  | SIdentifier<I>
   | SConditional<I>
   | SFunctionCall<I>
   | SFunction<I>
@@ -110,7 +110,7 @@ export interface SDefinition<I = {}> {
 
 export interface SExport<I = {}> {
   tag: "export";
-  value: SVariableReference<I>;
+  value: SIdentifier<I>;
   location: Location;
 }
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -6,8 +6,6 @@ import { TypeWithWildcards } from "./type-wildcards";
 // Expressions
 //
 
-export type SVar = string;
-
 interface Node<I> {
   location: Location;
   info: I;
@@ -23,6 +21,7 @@ export interface SString<I = {}> extends Node<I> {
   value: string;
 }
 
+type SVar = string;
 export interface SIdentifier<I = {}> extends Node<I> {
   tag: "identifier";
   name: SVar;

--- a/packages/delisp-core/src/typescript-generation.ts
+++ b/packages/delisp-core/src/typescript-generation.ts
@@ -135,7 +135,7 @@ export function generateTSDeclaration(
 ): string {
   switch (s.tag) {
     case "definition": {
-      const varname = identifierToJS(s.variable);
+      const varname = identifierToJS(s.variable.name);
       const typ = generateTSType(generalize(s.value.info.type, []));
       return `declare const ${varname}: ${typ};`;
     }
@@ -169,7 +169,7 @@ export function generateTSModuleDeclaration(m: Module<Typed>): string {
     declarations
       .map(d => {
         const tstype = generateTSDeclaration(d);
-        const active = d.tag === "definition" && isExported(d.variable, m);
+        const active = d.tag === "definition" && isExported(d.variable.name, m);
         return exportIf(active, tstype);
       })
       .join("\n") +

--- a/packages/delisp-core/src/typescript-generation.ts
+++ b/packages/delisp-core/src/typescript-generation.ts
@@ -140,7 +140,7 @@ export function generateTSDeclaration(
       return `declare const ${varname}: ${typ};`;
     }
     case "type-alias": {
-      const typename = identifierToJS(s.name);
+      const typename = identifierToJS(s.alias.name);
       const typ = generateTSType(generalize(s.definition, []));
       return `type ${typename} = ${typ};`;
     }

--- a/packages/delisp/src/cmd-repl.ts
+++ b/packages/delisp/src/cmd-repl.ts
@@ -99,7 +99,7 @@ function handleLine(line: string) {
 
 function completer(input: string): [string[], string] {
   const defs = previousModule.body.filter(isDefinition);
-  const completions = defs.map(d => d.variable);
+  const completions = defs.map(d => d.variable.name);
   return [completions, input];
 }
 
@@ -112,7 +112,10 @@ const delispEval = (syntax: Syntax) => {
   let m;
 
   if (isDefinition(syntax)) {
-    previousModule = removeModuleDefinition(previousModule, syntax.variable);
+    previousModule = removeModuleDefinition(
+      previousModule,
+      syntax.variable.name
+    );
     previousModule = addToModule(previousModule, syntax);
     m = previousModule;
   } else if (syntax.tag === "type-alias") {
@@ -161,7 +164,7 @@ const delispEval = (syntax: Syntax) => {
         : null;
 
     if (isDefinition(syntax)) {
-      return { type, name: syntax.variable };
+      return { type, name: syntax.variable.name };
     } else {
       return { type };
     }

--- a/packages/delisp/src/cmd-repl.ts
+++ b/packages/delisp/src/cmd-repl.ts
@@ -119,7 +119,10 @@ const delispEval = (syntax: Syntax) => {
     previousModule = addToModule(previousModule, syntax);
     m = previousModule;
   } else if (syntax.tag === "type-alias") {
-    previousModule = removeModuleTypeDefinition(previousModule, syntax.name);
+    previousModule = removeModuleTypeDefinition(
+      previousModule,
+      syntax.alias.name
+    );
     previousModule = addToModule(previousModule, syntax);
     m = previousModule;
   } else if (isExpression(syntax)) {


### PR DESCRIPTION
- Replaces `SVariableReference` completely
- Replaces `SVar` (alias for `string`) in most cases, so we have access to the location of identifiers.