### PR TITLE
Support for `do` blocks

### DIFF
--- a/editor/emacs/delisp.el
+++ b/editor/emacs/delisp.el
@@ -100,7 +100,7 @@
        (t
         (down-list)
         (case (symbol-at-point)
-          ((define lambda let the)
+          ((define lambda let the do)
            (* delisp-indent-level level))
           (t
            (forward-sexp 2)
@@ -168,7 +168,7 @@
          '(2 font-lock-variable-name-face))
 
    (list
-    (concat "(" (regexp-opt '("if" "lambda" "let" "export" "and" "or" "the") t) "\\>")
+    (concat "(" (regexp-opt '("if" "lambda" "let" "export" "and" "or" "the" "do") t) "\\>")
     '(1 font-lock-keyword-face))
 
    (list

--- a/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/compiler.ts.snap
@@ -239,3 +239,9 @@ exports[`Compiler Error messages generate nice error messages for invalid export
 (export 1 2 3)
 ------------^"
 `;
+
+exports[`Compiler Error messages generate nice errors for do-blocks 1`] = `
+"file:1:3: empty body
+(do)
+--^"
+`;

--- a/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
@@ -139,6 +139,13 @@ exports[`Pretty Printer should pretty print a combination of lambda and function
                       ttt))))"
 `;
 
+exports[`Pretty Printer should pretty print do blocks 1`] = `
+"
+(do
+  (print \\"hello\\")
+  (print \\"bye bye!\\"))"
+`;
+
 exports[`Pretty Printer should pretty print type declarations 1`] = `
 "
 (type Person {:name string :age number :books [{:name string :author string}]})"

--- a/packages/delisp-core/__tests__/compiler.ts
+++ b/packages/delisp-core/__tests__/compiler.ts
@@ -91,5 +91,9 @@ describe("Compiler", () => {
       expect(compileError("(export (+ 1 2))")).toMatchSnapshot();
       expect(compileError("(export 1 2 3)")).toMatchSnapshot();
     });
+
+    it("generate nice errors for do-blocks", () => {
+      expect(compileError("(do)")).toMatchSnapshot();
+    });
   });
 });

--- a/packages/delisp-core/__tests__/eval.ts
+++ b/packages/delisp-core/__tests__/eval.ts
@@ -128,4 +128,11 @@ describe("Evaluation", () => {
       expect(evaluateString("{:x 3 | {:x 1 :y 2}}")).toEqual({ x: 3, y: 2 });
     });
   });
+
+  describe("Do blocks", () => {
+    it("should evaluate to the last form", () => {
+      expect(evaluateString(`(do 1)`)).toBe(1);
+      expect(evaluateString(`(do 1 2)`)).toBe(2);
+    });
+  });
 });

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -219,5 +219,14 @@ describe("Type inference", () => {
         );
       });
     });
+
+    describe("Do blocks", () => {
+      it("type is the type of the last form", () => {
+        expect(typeOf("(do 1 2 3)")).toBe("number");
+      });
+      it("constraint types properly", () => {
+        expect(typeOf("(lambda (x) (print x) x)")).toBe("(-> string string)");
+      });
+    });
   });
 });

--- a/packages/delisp-core/__tests__/printer.ts
+++ b/packages/delisp-core/__tests__/printer.ts
@@ -230,4 +230,10 @@ eee
   it("should pretty print type type applications", () => {
     expect(pprintSource(`(the (a) 10)`)).toMatchSnapshot();
   });
+
+  it("should pretty print do blocks", () => {
+    expect(
+      pprintSource(`(do (print "hello") (print "bye bye!"))`)
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -14,7 +14,8 @@ import {
   SLet,
   SRecord,
   SVectorConstructor,
-  Syntax
+  Syntax,
+  SDoBlock
 } from "./syntax";
 
 import { methodCall } from "./compiler/estree-utils";
@@ -299,6 +300,15 @@ function compileNumber(value: number): JS.Expression {
   }
 }
 
+function compileDoBlock(expr: SDoBlock, env: Environment): JS.Expression {
+  return {
+    type: "SequenceExpression",
+    expressions: [...expr.node.body, expr.node.returning].map(e =>
+      compile(e, env)
+    )
+  };
+}
+
 export function compile(expr: Expression, env: Environment): JS.Expression {
   switch (expr.node.tag) {
     case "number":
@@ -321,6 +331,8 @@ export function compile(expr: Expression, env: Environment): JS.Expression {
       return compileLetBindings({ ...expr, node: expr.node }, env);
     case "type-annotation":
       return compile(expr.node.value, env);
+    case "do-block":
+      return compileDoBlock({ ...expr, node: expr.node }, env);
   }
 }
 

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -227,6 +227,28 @@ defineConversion("the", expr => {
   };
 });
 
+defineConversion("do", expr => {
+  const [_do, ...args] = expr.elements;
+  const lastExpr = last([_do, ...args]) as ASExpr; // we know it is not empty!
+
+  if (args.length === 0) {
+    throw new Error(
+      printHighlightedExpr(`empty body`, lastExpr.location, true)
+    );
+  }
+  const middleForms = args.slice(0, -1);
+  const lastForm = last(args)!;
+  return {
+    node: {
+      tag: "do-block",
+      body: middleForms.map(convertExpr),
+      returning: convertExpr(lastForm)
+    },
+    location: expr.location,
+    info: {}
+  };
+});
+
 defineToplevel("define", expr => {
   const [define, ...args] = expr.elements;
 

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -492,6 +492,26 @@ function infer(
         constraints: [...inferred.constraints, constEqual(inferred.result, t)]
       };
     }
+
+    case "do-block": {
+      const body = inferMany(expr.node.body, monovars, internalTypes);
+      const returning = infer(expr.node.returning, monovars, internalTypes);
+
+      return {
+        result: {
+          ...expr,
+          node: {
+            ...expr.node,
+            body: body.result,
+            returning: returning.result
+          },
+          info: { type: returning.result.info.type }
+        },
+
+        constraints: [...body.constraints, ...returning.constraints],
+        assumptions: [...body.assumptions, ...returning.assumptions]
+      };
+    }
   }
 }
 

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -133,6 +133,14 @@ function printExpr(expr: Expression): Doc {
             indent(concat(line, e.node.value))
           )
         );
+
+      case "do-block":
+        return list(
+          concat(
+            text("do"),
+            indent(concat(line, join([...e.node.body, e.node.returning], line)))
+          )
+        );
     }
   });
 }

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -83,6 +83,15 @@ export function mapExpr<I, A, B>(
           value: fn(expr.node.value)
         }
       };
+    case "do-block":
+      return {
+        ...expr,
+        node: {
+          ...expr.node,
+          body: expr.node.body.map(fn),
+          returning: fn(expr.node.returning)
+        }
+      };
   }
 }
 
@@ -123,6 +132,8 @@ function expressionChildren<I>(e: Expression<I>): Array<Expression<I>> {
       return [...e.node.fields.map(f => f.value)];
     case "type-annotation":
       return [e.node.value];
+    case "do-block":
+      return [...e.node.body, e.node.returning];
   }
 }
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -83,6 +83,12 @@ interface STypeAnnotationF<E> {
   typeWithWildcards: TypeWithWildcards;
 }
 
+interface SDoBlockF<E> {
+  tag: "do-block";
+  body: E[];
+  returning: E;
+}
+
 type AnyExpressionF<I = {}, E = Expression<I>> =
   | SNumberF
   | SStringF
@@ -93,7 +99,8 @@ type AnyExpressionF<I = {}, E = Expression<I>> =
   | SVectorConstructorF<E>
   | SLetF<E>
   | SRecordF<E>
-  | STypeAnnotationF<E>;
+  | STypeAnnotationF<E>
+  | SDoBlockF<E>;
 
 interface Node<I, E> {
   node: E;
@@ -123,6 +130,8 @@ export interface SRecord<I = {}> extends Node<I, SRecordF<Expression<I>>> {}
 
 export interface SVectorConstructor<I = {}>
   extends Node<I, SVectorConstructorF<Expression<I>>> {}
+
+export interface SDoBlock<I = {}> extends Node<I, SDoBlockF<Expression<I>>> {}
 
 //
 // Declarations


### PR DESCRIPTION
This pull request introduces a new special form `do`.

It works like

```lisp
(do
  form1
  form2
  ...
  form_n)
```

The form evaluates to the last value. The value of all the forms from 1 to n-1 are ignored. But they are still evaluated.

This is useful together with effectful code, so it can be used in places like `if`:

```lisp
(if true
  (do
    (print "foo")))
  ...)
```