### PR TITLE
Implementation of polymorphic variants

### DIFF
--- a/editor/emacs/delisp.el
+++ b/editor/emacs/delisp.el
@@ -100,7 +100,7 @@
        (t
         (down-list)
         (case (symbol-at-point)
-          ((define lambda let the do)
+          ((define lambda let the do match)
            (* delisp-indent-level level))
           (t
            (forward-sexp 2)
@@ -168,7 +168,7 @@
          '(2 font-lock-variable-name-face))
 
    (list
-    (concat "(" (regexp-opt '("if" "lambda" "let" "export" "and" "or" "the" "do") t) "\\>")
+    (concat "(" (regexp-opt '("if" "lambda" "let" "export" "and" "or" "the" "do" "match") t) "\\>")
     '(1 font-lock-keyword-face))
 
    (list

--- a/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/printer.ts.snap
@@ -85,6 +85,14 @@ exports[`Pretty Printer should align nested function calls 3`] = `
                ttt))"
 `;
 
+exports[`Pretty Printer should break long bodies in match expressions 1`] = `
+"
+(match value
+  ({:version number}
+    (+ 1234 1234 1234 1234 1234 123 1234 1234 1234 1234 1234 1234 number))
+  ({:unrelesed _} () number))"
+`;
+
 exports[`Pretty Printer should insert newlines 1`] = `
 "
 aaa
@@ -111,6 +119,13 @@ ccc
 ddd
 
 eee"
+`;
+
+exports[`Pretty Printer should pretty match expressions 1`] = `
+"
+(match value
+  ({:version number} number)
+  ({:unrelesed _} number))"
 `;
 
 exports[`Pretty Printer should pretty print a combination of lambda and function call 1`] = `
@@ -144,6 +159,17 @@ exports[`Pretty Printer should pretty print do blocks 1`] = `
 (do
   (print \\"hello\\")
   (print \\"bye bye!\\"))"
+`;
+
+exports[`Pretty Printer should pretty print tag forms 1`] = `
+"
+(tag :version 0)"
+`;
+
+exports[`Pretty Printer should pretty print tag forms with large expressions 1`] = `
+"
+(tag :version
+  this-is-a-extremely--long-and-annoying-variable-name-in-order-to-break-the-line)"
 `;
 
 exports[`Pretty Printer should pretty print type declarations 1`] = `

--- a/packages/delisp-core/__tests__/printer.ts
+++ b/packages/delisp-core/__tests__/printer.ts
@@ -236,4 +236,40 @@ eee
       pprintSource(`(do (print "hello") (print "bye bye!"))`)
     ).toMatchSnapshot();
   });
+
+  it("should pretty print tag forms", () => {
+    expect(pprintSource(`(tag :version 0)`)).toMatchSnapshot();
+  });
+
+  it("should pretty print tag forms with large expressions", () => {
+    expect(
+      pprintSource(
+        `(tag :version this-is-a-extremely--long-and-annoying-variable-name-in-order-to-break-the-line)`
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("should pretty match expressions", () => {
+    expect(
+      pprintSource(
+        `
+(match value
+  ({:version number} number)
+  ({:unrelesed _} number)
+)`
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("should break long bodies in match expressions", () => {
+    expect(
+      pprintSource(
+        `
+(match value
+  ({:version number} (+ 1234 1234 1234 1234 1234 123 1234 1234 1234 1234 1234 1234 number))
+  ({:unrelesed _} ()number)
+)`
+      )
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/delisp-core/src/__snapshots__/convert-type.spec.ts.snap
+++ b/packages/delisp-core/src/__snapshots__/convert-type.spec.ts.snap
@@ -146,6 +146,116 @@ Object {
 }
 `;
 
+exports[`convertType Variants should detect incorrect variants 1`] = `
+"
+file:1:3: Missing row
+(or)
+--^"
+`;
+
+exports[`convertType Variants should detect incorrect variants 2`] = `
+"
+file:1:5: The variants object should look like an record
+(or a)
+----^"
+`;
+
+exports[`convertType Variants should detect incorrect variants 3`] = `
+"
+file:1:8: Too many arguments for a variant type
+(or {} {})
+-------^"
+`;
+
+exports[`convertType Variants should read basic variant 1`] = `
+Object {
+  "node": Object {
+    "args": Array [
+      Object {
+        "node": Object {
+          "extends": Object {
+            "node": Object {
+              "extends": Object {
+                "node": Object {
+                  "tag": "empty-row",
+                },
+              },
+              "label": ":machine",
+              "labelType": Object {
+                "node": Object {
+                  "name": "number",
+                  "tag": "constant",
+                },
+              },
+              "tag": "row-extension",
+            },
+          },
+          "label": ":person",
+          "labelType": Object {
+            "node": Object {
+              "name": "string",
+              "tag": "constant",
+            },
+          },
+          "tag": "row-extension",
+        },
+      },
+    ],
+    "op": Object {
+      "node": Object {
+        "name": "or",
+        "tag": "constant",
+      },
+    },
+    "tag": "application",
+  },
+}
+`;
+
+exports[`convertType Variants should read empty variant 1`] = `
+Object {
+  "node": Object {
+    "args": Array [
+      Object {
+        "node": Object {
+          "tag": "empty-row",
+        },
+      },
+    ],
+    "op": Object {
+      "node": Object {
+        "name": "or",
+        "tag": "constant",
+      },
+    },
+    "tag": "application",
+  },
+}
+`;
+
+exports[`convertType Variants should read fully polymorphic variant 1`] = `
+Object {
+  "node": Object {
+    "args": Array [
+      Object {
+        "node": Object {
+          "name": "a",
+          "tag": "type-variable",
+          "userSpecified": false,
+        },
+      },
+    ],
+    "op": Object {
+      "node": Object {
+        "name": "or",
+        "tag": "constant",
+      },
+    },
+    "tag": "application",
+  },
+}
+`;
+
 exports[`convertType should detect incorrect types 1`] = `
 "
 file:1:1: Not a valid type

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -356,8 +356,8 @@ function compileMatch(expr: SMatch, env: Environment): JS.Expression {
           shorthand: false,
           computed: false,
           key: {
-            type: "Identifier",
-            name: identifierToJS(c.label)
+            type: "Literal",
+            value: c.label
           },
           value: {
             type: "ArrowFunctionExpression",

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -438,6 +438,12 @@ function compileRuntime(env: Environment): JS.Statement | JS.ModuleDeclaration {
   return env.moduleFormat.importRuntime("env");
 }
 
+function compileRuntimeUtils(
+  env: Environment
+): JS.Statement | JS.ModuleDeclaration {
+  return env.moduleFormat.importRuntimeUtils(["matchTag", "tag"]);
+}
+
 function compileExports(
   exps: SExport[],
   env: Environment
@@ -506,7 +512,9 @@ function compileModule(
     type: "Program",
     sourceType: "module",
     body: [
-      ...(includeRuntime ? [compileRuntime(env)] : []),
+      ...(includeRuntime
+        ? [compileRuntime(env), compileRuntimeUtils(env)]
+        : []),
       ...maybeMap((syntax: Syntax) => compileTopLevel(syntax, env), m.body),
       ...compileExports(m.body.filter(isExport), env)
     ]

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -13,6 +13,7 @@ import {
   SVariableReference,
   SLet,
   SMatch,
+  STag,
   SRecord,
   SVectorConstructor,
   Syntax,
@@ -382,6 +383,20 @@ function compileMatch(expr: SMatch, env: Environment): JS.Expression {
   };
 }
 
+function compileTag(expr: STag, env: Environment): JS.Expression {
+  return {
+    type: "CallExpression",
+    callee: {
+      type: "Identifier",
+      name: "tag"
+    },
+    arguments: [
+      { type: "Literal", value: expr.node.label },
+      compile(expr.node.value, env)
+    ]
+  };
+}
+
 function compileUnknown(_expr: SUnknown, env: Environment): JS.Expression {
   const unknownFn = compilePrimitive("unknown", env);
   const message = literal("Reached code that did not compile properly.");
@@ -423,6 +438,8 @@ export function compile(expr: Expression, env: Environment): JS.Expression {
       return compileDoBlock({ ...expr, node: expr.node }, env);
     case "match":
       return compileMatch({ ...expr, node: expr.node }, env);
+    case "tag":
+      return compileTag({ ...expr, node: expr.node }, env);
   }
 }
 

--- a/packages/delisp-core/src/convert-utils.ts
+++ b/packages/delisp-core/src/convert-utils.ts
@@ -1,10 +1,18 @@
 import { printHighlightedExpr } from "./error-report";
-import { ASExprMap } from "./sexpr";
+import { ASExpr, ASExprSymbol, ASExprMap } from "./sexpr";
 import { duplicatedItemsBy, last } from "./utils";
 
 export class ConvertError extends Error {}
 
-export function parseRecord(expr: ASExprMap) {
+export interface ParseRecordResult {
+  fields: Array<{
+    label: ASExprSymbol;
+    value: ASExpr;
+  }>;
+  tail: ASExpr | undefined;
+}
+
+export function parseRecord(expr: ASExprMap): ParseRecordResult {
   //
   // Destructure a map into fields and tail
   function fieldsAndTail() {

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -346,7 +346,7 @@ defineConversion("match", (_match, args, whole) => {
       return null;
     }
 
-    const [pattern, value] = c.elements;
+    const [pattern, ...bodyForms] = c.elements;
 
     if (pattern.tag !== "map") {
       errors.push(`The pattern must be a map`);
@@ -381,7 +381,7 @@ defineConversion("match", (_match, args, whole) => {
     return {
       label: record.fields[0].label.name,
       variable: parseIdentifier(variableSymbol),
-      value: convertExpr(value)
+      body: parseBody(c, bodyForms)
     };
   }, caseForms);
 

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -341,11 +341,6 @@ defineConversion("match", (_match, args, whole) => {
       return null;
     }
 
-    if (c.elements.length !== 2) {
-      errors.push(`ill-formatted case`);
-      return null;
-    }
-
     const [pattern, ...bodyForms] = c.elements;
 
     if (pattern.tag !== "map") {
@@ -368,7 +363,7 @@ defineConversion("match", (_match, args, whole) => {
     }
 
     if (record.fields.length !== 1) {
-      errors.push(`Expected a single fieldn`);
+      errors.push(`Expected a single field`);
       return null;
     }
 
@@ -378,8 +373,10 @@ defineConversion("match", (_match, args, whole) => {
       return null;
     }
 
+    const label = record.fields[0].label.name;
+
     return {
-      label: record.fields[0].label.name,
+      label,
       variable: parseIdentifier(variableSymbol),
       body: parseBody(c, bodyForms)
     };

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -393,6 +393,30 @@ defineConversion("match", (_match, args, whole) => {
   );
 });
 
+defineConversion("tag", (_tag, args, whole) => {
+  let [labelForm, valueForm] = args;
+
+  if (labelForm.tag !== "symbol" || !labelForm.name.startsWith(":")) {
+    throw new ConvertError(`Invalid tag!`);
+  }
+
+  const label = labelForm.name;
+
+  const value = valueForm
+    ? convertExpr(valueForm)
+    : missingFrom(whole, ["missing keyword"]);
+
+  return result(
+    {
+      tag: "tag",
+      label,
+      value
+    },
+    whole.location,
+    []
+  );
+});
+
 defineToplevel("define", (define_, args, whole) => {
   if (args.length !== 2) {
     const lastExpr = last([define_, ...args]) as ASExpr;

--- a/packages/delisp-core/src/eval.ts
+++ b/packages/delisp-core/src/eval.ts
@@ -8,10 +8,15 @@ import primitives from "./primitives";
 import { Module, Syntax } from "./syntax";
 import { mapObject } from "./utils";
 
+import { tag, matchTag } from "@delisp/runtime";
+
 export function createContext() {
   const sandbox = {
     env: mapObject(primitives, p => p.value),
-    console
+    console,
+    // Primitives
+    tag,
+    matchTag
   };
   vm.createContext(sandbox);
   return sandbox;

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -548,6 +548,7 @@ function infer(
           // Value must produce a value of type with all the variants
           // that `match` is handling.
           constEqual(value.result, tVariant(variantTypes)),
+          constEffect(value.result, effect),
 
           ...flatMap(c => {
             const returningForm = last(c.infer.result);
@@ -559,6 +560,8 @@ function infer(
             return [
               // Each case must return a value of the same type
               constEqual(returningForm, t),
+
+              ...c.infer.result.map(f => constEffect(f, effect)),
 
               // The pattern variable of each case must be the same
               // type as the variant we are handling.

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -597,7 +597,10 @@ function infer(
       const inferredValue = infer(expr.node.value, monovars, internalTypes);
 
       const labelType = generateUniqueTVar();
-      const t = tVariant([{ label: expr.node.label, type: labelType }]);
+      const t = tVariant(
+        [{ label: expr.node.label, type: labelType }],
+        generateUniqueTVar()
+      );
       const effect = generateUniqueTVar();
 
       return {

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -592,6 +592,37 @@ function infer(
         ]
       };
     }
+
+    case "tag": {
+      const inferredValue = infer(expr.node.value, monovars, internalTypes);
+
+      const labelType = generateUniqueTVar();
+      const t = tVariant([{ label: expr.node.label, type: labelType }]);
+      const effect = generateUniqueTVar();
+
+      return {
+        result: {
+          ...expr,
+          node: {
+            ...expr.node,
+            label: expr.node.label,
+            value: inferredValue.result
+          },
+          info: {
+            type: t,
+            effect
+          }
+        },
+
+        constraints: [
+          ...inferredValue.constraints,
+          constEffect(inferredValue.result, effect),
+          constEqual(inferredValue.result, labelType)
+        ],
+
+        assumptions: [...inferredValue.assumptions]
+      };
+    }
   }
 }
 

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -153,7 +153,36 @@ function printExpr(expr: Expression): Doc {
         );
 
       case "match":
-        throw new Error(`not supported`);
+        return list(
+          concat(
+            text("match", "keyword", source),
+            space,
+            e.node.value,
+            indent(
+              concat(
+                line,
+                join(
+                  e.node.cases.map(c => {
+                    return group(
+                      concat(
+                        list(
+                          map(
+                            text(c.label, "keyword"),
+                            space,
+                            printIdentifier(c.variable.name)
+                          ),
+                          line,
+                          join(c.body, line)
+                        )
+                      )
+                    );
+                  }),
+                  line
+                )
+              )
+            )
+          )
+        );
     }
   });
 }

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -182,6 +182,16 @@ function printExpr(expr: Expression): Doc {
             )
           )
         );
+
+      case "tag":
+        return group(
+          list(
+            text("tag", "keyword", source),
+            space,
+            text(e.node.label, "label"),
+            indent(concat(line, e.node.value))
+          )
+        );
     }
   });
 }

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -151,6 +151,9 @@ function printExpr(expr: Expression): Doc {
             indent(concat(line, join([...e.node.body, e.node.returning], line)))
           )
         );
+
+      case "match":
+        throw new Error(`not supported`);
     }
   });
 }

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -171,8 +171,7 @@ function printExpr(expr: Expression): Doc {
                             space,
                             printIdentifier(c.variable.name)
                           ),
-                          line,
-                          join(c.body, line)
+                          indent(concat(line, join(c.body, line)))
                         )
                       )
                     );

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -1,4 +1,5 @@
 import { assertNever, InvariantViolation } from "./invariant";
+import { flatten } from "./utils";
 import {
   isExpression,
   ExpressionF,
@@ -102,7 +103,7 @@ export function mapExpr<I, A, B>(
           cases: expr.node.cases.map(c => ({
             label: c.label,
             variable: c.variable,
-            value: fn(c.value)
+            body: c.body.map(fn)
           }))
         }
       };
@@ -133,7 +134,7 @@ export function exprFChildren<I, E>(e: ExpressionF<I, E>): E[] {
     case "do-block":
       return [...e.node.body, e.node.returning];
     case "match":
-      return [e.node.value, ...e.node.cases.map(c => c.value)];
+      return [e.node.value, ...flatten(e.node.cases.map(c => c.body))];
   }
 }
 

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -93,6 +93,19 @@ export function mapExpr<I, A, B>(
           returning: fn(expr.node.returning)
         }
       };
+    case "match":
+      return {
+        ...expr,
+        node: {
+          ...expr.node,
+          value: fn(expr.node.value),
+          cases: expr.node.cases.map(c => ({
+            label: c.label,
+            variable: c.variable,
+            value: fn(c.value)
+          }))
+        }
+      };
   }
 }
 
@@ -119,6 +132,8 @@ export function exprFChildren<I, E>(e: ExpressionF<I, E>): E[] {
       return [e.node.value];
     case "do-block":
       return [...e.node.body, e.node.returning];
+    case "match":
+      return [e.node.value, ...e.node.cases.map(c => c.value)];
   }
 }
 

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -107,6 +107,15 @@ export function mapExpr<I, A, B>(
           }))
         }
       };
+    case "tag":
+      return {
+        ...expr,
+        node: {
+          ...expr.node,
+          label: expr.node.label,
+          value: fn(expr.node.value)
+        }
+      };
   }
 }
 
@@ -135,6 +144,8 @@ export function exprFChildren<I, E>(e: ExpressionF<I, E>): E[] {
       return [...e.node.body, e.node.returning];
     case "match":
       return [e.node.value, ...flatten(e.node.cases.map(c => c.body))];
+    case "tag":
+      return [e.node.value];
   }
 }
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -92,7 +92,7 @@ interface SDoBlockF<E> {
 export interface SMatchCaseF<E> {
   label: string;
   variable: Identifier;
-  value: E;
+  body: E[];
 }
 
 interface SMatchF<E> {

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -101,6 +101,12 @@ interface SMatchF<E> {
   cases: Array<SMatchCaseF<E>>;
 }
 
+interface STagF<E> {
+  tag: "tag";
+  label: string;
+  value: E;
+}
+
 interface SUnknownF<_E> {
   tag: "unknown";
 }
@@ -118,6 +124,7 @@ type AnyExpressionF<I = {}, E = Expression<I>> =
   | STypeAnnotationF<E>
   | SDoBlockF<E>
   | SMatchF<E>
+  | STagF<E>
   | SUnknownF<E>;
 
 interface Node<I, E> {
@@ -152,6 +159,8 @@ export interface SVectorConstructor<I = {}>
 export interface SDoBlock<I = {}> extends Node<I, SDoBlockF<Expression<I>>> {}
 
 export interface SMatch<I = {}> extends Node<I, SMatchF<Expression<I>>> {}
+
+export interface STag<I = {}> extends Node<I, STagF<Expression<I>>> {}
 
 export interface SUnknown<I = {}> extends Node<I, SUnknownF<Expression<I>>> {}
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -89,6 +89,16 @@ interface SDoBlockF<E> {
   returning: E;
 }
 
+interface SMatchF<E> {
+  tag: "match";
+  value: E;
+  cases: Array<{
+    label: string;
+    variable: Identifier;
+    value: E;
+  }>;
+}
+
 interface SUnknownF<_E> {
   tag: "unknown";
 }
@@ -105,6 +115,7 @@ type AnyExpressionF<I = {}, E = Expression<I>> =
   | SRecordF<E>
   | STypeAnnotationF<E>
   | SDoBlockF<E>
+  | SMatchF<E>
   | SUnknownF<E>;
 
 interface Node<I, E> {
@@ -137,6 +148,8 @@ export interface SVectorConstructor<I = {}>
   extends Node<I, SVectorConstructorF<Expression<I>>> {}
 
 export interface SDoBlock<I = {}> extends Node<I, SDoBlockF<Expression<I>>> {}
+
+export interface SMatch<I = {}> extends Node<I, SMatchF<Expression<I>>> {}
 
 export interface SUnknown<I = {}> extends Node<I, SUnknownF<Expression<I>>> {}
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -89,14 +89,16 @@ interface SDoBlockF<E> {
   returning: E;
 }
 
+export interface SMatchCaseF<E> {
+  label: string;
+  variable: Identifier;
+  value: E;
+}
+
 interface SMatchF<E> {
   tag: "match";
   value: E;
-  cases: Array<{
-    label: string;
-    variable: Identifier;
-    value: E;
-  }>;
+  cases: Array<SMatchCaseF<E>>;
 }
 
 interface SUnknownF<_E> {

--- a/packages/delisp-core/src/type-printer.ts
+++ b/packages/delisp-core/src/type-printer.ts
@@ -63,6 +63,20 @@ function printApplicationType(type: TApplication): string {
         : " | " + _printType(row.extends);
 
     return `(effect${fields}${extending})`;
+  } else if (
+    type.node.op.node.tag === "constant" &&
+    type.node.op.node.name === "or"
+  ) {
+    const arg = type.node.args[0];
+    const row = normalizeRow(arg);
+    const fields = row.fields
+      .map(f => `${f.label} ${_printType(f.labelType)}`)
+      .join(" ");
+    const extension =
+      row.extends.node.tag !== "empty-row"
+        ? ` | ${_printType(row.extends)}`
+        : "";
+    return `(or {${fields}${extension}})`;
   } else {
     return (
       "(" + [type.node.op, ...type.node.args].map(_printType).join(" ") + ")"

--- a/packages/delisp-core/src/types.ts
+++ b/packages/delisp-core/src/types.ts
@@ -66,6 +66,8 @@ export const tcArrow = tConstant("->");
 export const tcVector = tConstant("vector");
 // row -> *
 export const tcRecord = tConstant("record");
+// row -> *
+export const tcOr = tConstant("or");
 // *
 export const tVoid = tConstant("void");
 export const tBoolean = tConstant("boolean");
@@ -143,4 +145,11 @@ export function tRecord(
   extending: Type = emptyRow
 ): Type {
   return tApp(tcRecord, tRow(fields, extending));
+}
+
+export function tVariant(
+  variants: Array<{ label: string; type: Type }>,
+  extending: Type = emptyRow
+): Type {
+  return tApp(tcOr, tRow(variants, extending));
 }

--- a/packages/delisp-runtime/src/index.ts
+++ b/packages/delisp-runtime/src/index.ts
@@ -6,3 +6,24 @@ export default Object.entries(primitives).reduce(
   (runtime, [name, def]) => ({ ...runtime, [name]: def.value }),
   {}
 );
+
+//
+// Variants
+//
+
+interface TaggedValue {
+  tag: string;
+  value: unknown;
+}
+
+export function matchTag(
+  obj: TaggedValue,
+  cases: { [label: string]: (value: unknown) => unknown }
+): unknown {
+  const handler = cases[obj.tag];
+  return handler(obj.value);
+}
+
+export function tag(tag: string, value: unknown): TaggedValue {
+  return { tag, value };
+}

--- a/packages/delisp-runtime/src/index.ts
+++ b/packages/delisp-runtime/src/index.ts
@@ -11,9 +11,13 @@ export default Object.entries(primitives).reduce(
 // Variants
 //
 
-interface TaggedValue {
+export class TaggedValue {
   tag: string;
   value: unknown;
+  constructor(tag: string, value: unknown) {
+    this.tag = tag;
+    this.value = value;
+  }
 }
 
 export function matchTag(
@@ -25,5 +29,5 @@ export function matchTag(
 }
 
 export function tag(tag: string, value: unknown): TaggedValue {
-  return { tag, value };
+  return new TaggedValue(tag, value);
 }

--- a/packages/delisp/init.dl
+++ b/packages/delisp/init.dl
@@ -1,3 +1,9 @@
 (define >>>
   (lambda (f1 f2)
     (lambda (x) (f2 (f1 x)))))
+
+(define test
+  (lambda (x)
+    (match x
+      ({:person name} 1)
+      ({:machine name} name))))

--- a/packages/delisp/init.dl
+++ b/packages/delisp/init.dl
@@ -1,11 +1,3 @@
 (define >>>
   (lambda (f1 f2)
     (lambda (x) (f2 (f1 x)))))
-
-(define test
-  (lambda (x)
-    (match x
-      ({:person name}
-        (print name)
-        name)
-      ({:machine version} "noname"))))

--- a/packages/delisp/init.dl
+++ b/packages/delisp/init.dl
@@ -5,5 +5,7 @@
 (define test
   (lambda (x)
     (match x
-      ({:person name} 1)
-      ({:machine name} name))))
+      ({:person name}
+        (print name)
+        name)
+      ({:machine version} "noname"))))

--- a/packages/delisp/package.json
+++ b/packages/delisp/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "@delisp/core": "^0.2.0",
+    "@delisp/runtime": "^0.2.0",
     "@types/debug": "^4.1.4",
     "@types/mkdirp": "^0.5.2",
     "chalk": "^2.4.2",

--- a/packages/delisp/src/cmd-repl.ts
+++ b/packages/delisp/src/cmd-repl.ts
@@ -1,5 +1,6 @@
 import * as fs from "./fs-helpers";
 import path from "path";
+import { TaggedValue } from "@delisp/runtime";
 
 import { CommandModule } from "yargs";
 
@@ -196,6 +197,8 @@ function printValue(value: any): string {
     return `"${value}"`;
   } else if (value === undefined || value === null) {
     return "#<undefined>";
+  } else if (value instanceof TaggedValue) {
+    return `(tag ${value.tag} ${value.value})`;
   } else if (Array.isArray(value)) {
     return `[${value.map(printValue).join(" ")}]`;
   } else if (typeof value === "object") {

--- a/packages/delisp/tsconfig.json
+++ b/packages/delisp/tsconfig.json
@@ -5,6 +5,7 @@
   },
   "include": ["./src/"],
   "references": [
-    { "path": "../delisp-core/tsconfig.build.json" }
+    { "path": "../delisp-core/tsconfig.build.json" },
+    { "path": "../delisp-runtime/tsconfig.json" }
   ]
 }


### PR DESCRIPTION
This pull request implements polymorphic variants on top of the rows that the record system introduced.

The syntax introduced here is temporary. It is clumsy and it has important limitations. For example, it does not support enumeration types (without associated value).

Variant types are described with the operator `or`:

`(or {:version number :unreleased string})`

means a **choice** of the labels `:version` (with a number),  or `:unreleased` with a string value.


Two special forms were introduced:

- `tag`, tag a value with a label, producing an open variant.

```
(the (or {:version number | α})
  (tag :version 0))
```

The general for of tag is `(tag LABEL <expression>)`.

- `match` to dispatch a variant based on the value:

```
(match x
  ({:version number}   number)
  ({:unreleased _) -1)
```

The general form of `match` is

```
(match <value>
  (<pattern> <expr1> <expr2> ... <exprN>)
  ...)
```
