### PR TITLE
Support for multiple values similar to Common Lisp

### DIFF
--- a/editor/emacs/delisp.el
+++ b/editor/emacs/delisp.el
@@ -102,6 +102,17 @@
         (case (symbol-at-point)
           ((define lambda let the do match)
            (* delisp-indent-level level))
+          ((multiple-value-bind)
+
+           (condition-case err
+               (forward-sexp 3)
+             (scan-error
+              err
+              (goto-char (third err))))
+           
+           (if (< (point) pos)
+               (* delisp-indent-level level)
+             (* delisp-indent-level (+ level 1))))
           (t
            (forward-sexp 2)
            (backward-sexp)
@@ -168,7 +179,7 @@
          '(2 font-lock-variable-name-face))
 
    (list
-    (concat "(" (regexp-opt '("if" "lambda" "let" "export" "and" "case" "the" "do" "match") t) "\\>")
+    (concat "(" (regexp-opt '("if" "lambda" "let" "export" "and" "case" "the" "do" "match" "multiple-value-bind" "values") t) "\\>")
     '(1 font-lock-keyword-face))
 
    (list

--- a/examples/test-todo.js
+++ b/examples/test-todo.js
@@ -8,8 +8,10 @@ const {
 
 let state = initialState;
 
-state = reducer(state, addTodo("Write todo app!"));
-state = reducer(state, completeAll());
-state = reducer(state, addTodo("Complete more todos"));
+const id = x => x;
 
-showTodos(state);
+state = reducer(id, state, addTodo(id, "Write todo app!"));
+state = reducer(id, state, completeAll(id));
+state = reducer(id, state, addTodo(id, "Complete more todos"));
+
+showTodos(id, state);

--- a/packages/delisp-core/__tests__/__snapshots__/convert.ts.snap
+++ b/packages/delisp-core/__tests__/__snapshots__/convert.ts.snap
@@ -233,3 +233,43 @@ exports[`Convert Error messages generate nice errors for do-blocks 1`] = `
 (do)
 --^"
 `;
+
+exports[`Convert Error messages generaten nice errors for multiple-value-bind form 1`] = `
+"file:1:1: Ill-formed form. 
+
+(multiple-value-bind (variable1 variable2 ...) 
+    form 
+  ...body)
+(multiple-value-bind)
+^"
+`;
+
+exports[`Convert Error messages generaten nice errors for multiple-value-bind form 2`] = `
+"file:1:1: Ill-formed form. 
+
+(multiple-value-bind (variable1 variable2 ...) 
+    form 
+  ...body)
+(multiple-value-bind x)
+^"
+`;
+
+exports[`Convert Error messages generaten nice errors for multiple-value-bind form 3`] = `
+"file:1:1: Ill-formed form. 
+
+(multiple-value-bind (variable1 variable2 ...) 
+    form 
+  ...body)
+(multiple-value-bind x y)
+^"
+`;
+
+exports[`Convert Error messages generaten nice errors for multiple-value-bind form 4`] = `
+"file:1:1: Ill-formed form. 
+
+(multiple-value-bind (variable1 variable2 ...) 
+    form 
+  ...body)
+(multiple-value-bind (x) y)
+^"
+`;

--- a/packages/delisp-core/__tests__/convert.ts
+++ b/packages/delisp-core/__tests__/convert.ts
@@ -96,5 +96,12 @@ describe("Convert", () => {
     it("generate nice errors for do-blocks", () => {
       expect(compileError("(do)")).toMatchSnapshot();
     });
+
+    it("generaten nice errors for multiple-value-bind form", () => {
+      expect(compileError("(multiple-value-bind)")).toMatchSnapshot();
+      expect(compileError("(multiple-value-bind x)")).toMatchSnapshot();
+      expect(compileError("(multiple-value-bind x y)")).toMatchSnapshot();
+      expect(compileError("(multiple-value-bind (x) y)")).toMatchSnapshot();
+    });
   });
 });

--- a/packages/delisp-core/__tests__/eval.ts
+++ b/packages/delisp-core/__tests__/eval.ts
@@ -135,4 +135,21 @@ describe("Evaluation", () => {
       expect(evaluateString(`(do 1 2)`)).toBe(2);
     });
   });
+
+  describe("Multiple values", () => {
+    it("uses the primary value by default", () => {
+      expect(evaluateString(`(+ 1 (values 2 10))`)).toBe(3);
+      expect(evaluateString(`(+ (values 1) (values 2 10))`)).toBe(3);
+    });
+
+    it("multiple-value-bind can catch forms with a single value transparently", () => {
+      expect(evaluateString(`(multiple-value-bind (x) 3 x)`)).toBe(3);
+    });
+
+    it("multiple-value-bind can catch forms with a multiple values", () => {
+      expect(
+        evaluateString(`(multiple-value-bind (x y) (values 3 7) (+ x y))`)
+      ).toBe(10);
+    });
+  });
 });

--- a/packages/delisp-core/__tests__/infer.ts
+++ b/packages/delisp-core/__tests__/infer.ts
@@ -225,6 +225,24 @@ describe("Type inference", () => {
       });
     });
 
+    describe("Primitive functions", () => {
+      it("map with multiple values", () => {
+        expect(typeOf("(map (lambda (x) (values x x)) [1 2 3 4])")).toEqual(
+          "[number]"
+        );
+      });
+      it("filter with multiple values", () => {
+        expect(
+          typeOf("(filter (lambda (x) (values true 5)) [-2 -1 0 1 2])")
+        ).toEqual("[number]");
+      });
+      it("fold with multiple values", () => {
+        expect(
+          typeOf(`(fold (lambda (a b) (values 50 (+ a b))) [1 2 3 4] 0)`)
+        ).toEqual("number");
+      });
+    });
+
     describe("Type annotations", () => {
       it("user-specified variables can specialize inferred types", () => {
         expect(typeOf("(the [number] [])")).toBe("[number]");

--- a/packages/delisp-core/__tests__/unify.ts
+++ b/packages/delisp-core/__tests__/unify.ts
@@ -23,7 +23,7 @@ describe("Unification", () => {
       const t1 = tFn([tNumber, tNumber], tVar("_"), tNumber);
       const t2 = tFn([tNumber], tVar("_"), tNumber);
       const result = unify(t1, t2, {});
-      expect(result.tag).toBe("unify-missing-value-error");
+      expect(result.tag).toBe("unify-mismatch-error");
     });
     it("should catch operator mismatches", () => {
       const t1 = tVector(tNumber);

--- a/packages/delisp-core/src/__snapshots__/convert-type.spec.ts.snap
+++ b/packages/delisp-core/src/__snapshots__/convert-type.spec.ts.snap
@@ -299,6 +299,119 @@ Object {
 }
 `;
 
+exports[`convertType Values type should read open value types 1`] = `
+Object {
+  "node": Object {
+    "args": Array [
+      Object {
+        "node": Object {
+          "extends": Object {
+            "node": Object {
+              "name": "a",
+              "tag": "type-variable",
+              "userSpecified": false,
+            },
+          },
+          "label": "0",
+          "labelType": Object {
+            "node": Object {
+              "name": "string",
+              "tag": "constant",
+            },
+          },
+          "tag": "row-extension",
+        },
+      },
+    ],
+    "op": Object {
+      "node": Object {
+        "name": "values",
+        "tag": "constant",
+      },
+    },
+    "tag": "application",
+  },
+}
+`;
+
+exports[`convertType Values type should read the single basic type 1`] = `
+Object {
+  "node": Object {
+    "args": Array [
+      Object {
+        "node": Object {
+          "extends": Object {
+            "node": Object {
+              "tag": "empty-row",
+            },
+          },
+          "label": "0",
+          "labelType": Object {
+            "node": Object {
+              "name": "number",
+              "tag": "constant",
+            },
+          },
+          "tag": "row-extension",
+        },
+      },
+    ],
+    "op": Object {
+      "node": Object {
+        "name": "values",
+        "tag": "constant",
+      },
+    },
+    "tag": "application",
+  },
+}
+`;
+
+exports[`convertType Values type should read the two values type 1`] = `
+Object {
+  "node": Object {
+    "args": Array [
+      Object {
+        "node": Object {
+          "extends": Object {
+            "node": Object {
+              "extends": Object {
+                "node": Object {
+                  "tag": "empty-row",
+                },
+              },
+              "label": "1",
+              "labelType": Object {
+                "node": Object {
+                  "name": "number",
+                  "tag": "constant",
+                },
+              },
+              "tag": "row-extension",
+            },
+          },
+          "label": "0",
+          "labelType": Object {
+            "node": Object {
+              "name": "string",
+              "tag": "constant",
+            },
+          },
+          "tag": "row-extension",
+        },
+      },
+    ],
+    "op": Object {
+      "node": Object {
+        "name": "values",
+        "tag": "constant",
+      },
+    },
+    "tag": "application",
+  },
+}
+`;
+
 exports[`convertType should detect incorrect types 1`] = `
 "
 file:1:1: Not a valid type

--- a/packages/delisp-core/src/compiler.ts
+++ b/packages/delisp-core/src/compiler.ts
@@ -156,7 +156,7 @@ function compileLambda(
 
   return {
     type: "ArrowFunctionExpression",
-    params: [...jsargs],
+    params: [identifier("values"), ...jsargs],
     body,
     expression: implicitReturn
   };
@@ -181,7 +181,7 @@ function compileFunctionCall(
     const jscall: JS.Expression = {
       type: "CallExpression",
       callee: compile(funcall.node.fn, env, false),
-      arguments: compiledArgs
+      arguments: [identifier("id"), ...compiledArgs]
     };
     return multipleValues ? jscall : primaryValue(jscall);
   }
@@ -597,7 +597,9 @@ function compileRuntimeUtils(
     "snd",
     "primaryValue",
     "values",
-    "mvbind"
+    "mvbind",
+    "id",
+    "bindPrimaryValue"
   ]);
 }
 

--- a/packages/delisp-core/src/compiler/estree-utils.ts
+++ b/packages/delisp-core/src/compiler/estree-utils.ts
@@ -63,7 +63,3 @@ export function primitiveCall(
     arguments: args
   };
 }
-
-export function primaryValue(x: JS.Expression): JS.Expression {
-  return primitiveCall("primaryValue", x);
-}

--- a/packages/delisp-core/src/compiler/estree-utils.ts
+++ b/packages/delisp-core/src/compiler/estree-utils.ts
@@ -63,3 +63,7 @@ export function primitiveCall(
     arguments: args
   };
 }
+
+export function primaryValue(x: JS.Expression): JS.Expression {
+  return primitiveCall("primaryValue", x);
+}

--- a/packages/delisp-core/src/compiler/inline-primitives.ts
+++ b/packages/delisp-core/src/compiler/inline-primitives.ts
@@ -107,7 +107,7 @@ export function compileInlinePrimitive(
     );
     return {
       type: "ArrowFunctionExpression",
-      params: identifiers,
+      params: [identifier("values"), ...identifiers],
       body: prim.handle(identifiers),
       expression: true
     };
@@ -175,14 +175,16 @@ defineInlinePrimitive("*", "(-> number number _ number)", args => {
 });
 
 defineInlinePrimitive("map", "(-> (-> a e b) [a] e [b])", ([fn, vec]) => {
-  return methodCall(vec, "map", [fn]);
+  return methodCall(vec, "map", [primitiveCall("bindPrimaryValue", fn)]);
 });
 
 defineInlinePrimitive(
   "filter",
   "(-> (-> a _ boolean) [a] _ [a])",
   ([predicate, vec]) => {
-    return methodCall(vec, "filter", [predicate]);
+    return methodCall(vec, "filter", [
+      primitiveCall("bindPrimaryValue", predicate)
+    ]);
   }
 );
 
@@ -190,7 +192,10 @@ defineInlinePrimitive(
   "fold",
   "(-> (-> b a _ b) [a] b _ b)",
   ([fn, vec, init]) => {
-    return methodCall(vec, "reduce", [fn, init]);
+    return methodCall(vec, "reduce", [
+      primitiveCall("bindPrimaryValue", fn),
+      init
+    ]);
   }
 );
 

--- a/packages/delisp-core/src/compiler/inline-primitives.ts
+++ b/packages/delisp-core/src/compiler/inline-primitives.ts
@@ -174,13 +174,17 @@ defineInlinePrimitive("*", "(-> number number _ number)", args => {
   };
 });
 
-defineInlinePrimitive("map", "(-> (-> a e b) [a] e [b])", ([fn, vec]) => {
-  return methodCall(vec, "map", [primitiveCall("bindPrimaryValue", fn)]);
-});
+defineInlinePrimitive(
+  "map",
+  "(-> (-> a e (values b | _)) [a] e [b])",
+  ([fn, vec]) => {
+    return methodCall(vec, "map", [primitiveCall("bindPrimaryValue", fn)]);
+  }
+);
 
 defineInlinePrimitive(
   "filter",
-  "(-> (-> a _ boolean) [a] _ [a])",
+  "(-> (-> a _ (values boolean | _)) [a] _ [a])",
   ([predicate, vec]) => {
     return methodCall(vec, "filter", [
       primitiveCall("bindPrimaryValue", predicate)
@@ -190,7 +194,7 @@ defineInlinePrimitive(
 
 defineInlinePrimitive(
   "fold",
-  "(-> (-> b a _ b) [a] b _ b)",
+  "(-> (-> b a _ (values b | _)) [a] b _ b)",
   ([fn, vec, init]) => {
     return methodCall(vec, "reduce", [
       primitiveCall("bindPrimaryValue", fn),

--- a/packages/delisp-core/src/convert-type.spec.ts
+++ b/packages/delisp-core/src/convert-type.spec.ts
@@ -114,4 +114,18 @@ describe("convertType", () => {
       expect(failedType(`(cases {} {})`)).toMatchSnapshot();
     });
   });
+
+  describe("Values type", () => {
+    it("should read the single basic type", () => {
+      expect(readAndConvert("(values number)")).toMatchSnapshot();
+    });
+
+    it("should read the two values type", () => {
+      expect(readAndConvert("(values string number)")).toMatchSnapshot();
+    });
+
+    it("should read open value types", () => {
+      expect(readAndConvert("(values string | a)")).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/delisp-core/src/convert-type.ts
+++ b/packages/delisp-core/src/convert-type.ts
@@ -159,13 +159,13 @@ function convertValues(expr: ASExpr): Type {
 
 function convertList(expr: ASExprList): Type {
   const [op, ...args] = expr.elements;
-  if (op.tag === "symbol" && op.name === "effect") {
+  if (isSymbolOfName(op, "effect")) {
     return convertEffect(args);
-  } else if (op.tag === "symbol" && op.name === "cases") {
+  } else if (isSymbolOfName(op, "cases")) {
     return convertCases(op, args);
-  } else if (op.tag === "symbol" && op.name === "values") {
+  } else if (isSymbolOfName(op, "values")) {
     return convertValues(expr);
-  } else if (op.tag === "symbol" && op.name === "->") {
+  } else if (isSymbolOfName(op, "->")) {
     if (args.length < 2) {
       throw new ConvertError(`Missing some arguments!`);
     }

--- a/packages/delisp-core/src/convert.ts
+++ b/packages/delisp-core/src/convert.ts
@@ -450,6 +450,14 @@ defineConversion("case", (case_, args, whole) => {
   );
 });
 
+defineConversion("values", (_values, args, whole) => {
+  return result(
+    { tag: "values", values: args.map(convertExpr) },
+    whole.location,
+    []
+  );
+});
+
 defineToplevel("define", (define_, args, whole) => {
   if (args.length !== 2) {
     const lastExpr = last([define_, ...args]) as ASExpr;

--- a/packages/delisp-core/src/eval.ts
+++ b/packages/delisp-core/src/eval.ts
@@ -15,7 +15,8 @@ import {
   fst,
   snd,
   values,
-  primaryValue
+  primaryValue,
+  mvbind
 } from "@delisp/runtime";
 
 export function createContext() {
@@ -29,7 +30,8 @@ export function createContext() {
     fst,
     snd,
     values,
-    primaryValue
+    primaryValue,
+    mvbind
   };
   vm.createContext(sandbox);
   return sandbox;

--- a/packages/delisp-core/src/eval.ts
+++ b/packages/delisp-core/src/eval.ts
@@ -16,7 +16,9 @@ import {
   snd,
   values,
   primaryValue,
-  mvbind
+  mvbind,
+  id,
+  bindPrimaryValue
 } from "@delisp/runtime";
 
 export function createContext() {
@@ -31,7 +33,9 @@ export function createContext() {
     snd,
     values,
     primaryValue,
-    mvbind
+    mvbind,
+    id,
+    bindPrimaryValue
   };
   vm.createContext(sandbox);
   return sandbox;

--- a/packages/delisp-core/src/eval.ts
+++ b/packages/delisp-core/src/eval.ts
@@ -16,8 +16,6 @@ import {
   snd,
   values,
   primaryValue,
-  mvbind,
-  id,
   bindPrimaryValue
 } from "@delisp/runtime";
 
@@ -33,8 +31,6 @@ export function createContext() {
     snd,
     values,
     primaryValue,
-    mvbind,
-    id,
     bindPrimaryValue
   };
   vm.createContext(sandbox);

--- a/packages/delisp-core/src/eval.ts
+++ b/packages/delisp-core/src/eval.ts
@@ -8,7 +8,15 @@ import primitives from "./primitives";
 import { Module, Syntax } from "./syntax";
 import { mapObject } from "./utils";
 
-import { caseTag, matchTag, pair, fst, snd } from "@delisp/runtime";
+import {
+  caseTag,
+  matchTag,
+  pair,
+  fst,
+  snd,
+  values,
+  primaryValue
+} from "@delisp/runtime";
 
 export function createContext() {
   const sandbox = {
@@ -19,7 +27,9 @@ export function createContext() {
     matchTag,
     pair,
     fst,
-    snd
+    snd,
+    values,
+    primaryValue
   };
   vm.createContext(sandbox);
   return sandbox;

--- a/packages/delisp-core/src/index.ts
+++ b/packages/delisp-core/src/index.ts
@@ -10,7 +10,8 @@ export {
   moduleEnvironment
 } from "./compiler";
 export { createContext, evaluate, evaluateModule } from "./eval";
-export { inferType, inferModule } from "./infer";
+export { inferType, inferModule, inferExpressionInModule } from "./infer";
+export { Type } from "./types";
 export { printType } from "./type-printer";
 export {
   isDeclaration,
@@ -34,7 +35,9 @@ export {
   readModule,
   addToModule,
   removeModuleDefinition,
-  removeModuleTypeDefinition
+  removeModuleTypeDefinition,
+  moduleDefinitions,
+  moduleDefinitionByName
 } from "./module";
 
 export { generateTSModuleDeclaration } from "./typescript-generation";

--- a/packages/delisp-core/src/index.ts
+++ b/packages/delisp-core/src/index.ts
@@ -10,7 +10,12 @@ export {
   moduleEnvironment
 } from "./compiler";
 export { createContext, evaluate, evaluateModule } from "./eval";
-export { inferType, inferModule, inferExpressionInModule } from "./infer";
+export {
+  inferType,
+  inferModule,
+  inferExpressionInModule,
+  defaultEnvironment
+} from "./infer";
 export { Type } from "./types";
 export { printType } from "./type-printer";
 export {

--- a/packages/delisp-core/src/infer-subst.ts
+++ b/packages/delisp-core/src/infer-subst.ts
@@ -8,10 +8,12 @@ export function applySubstitutionToExpr(
 ): Expression<Typed> {
   return transformRecurExpr(s, expr => ({
     ...expr,
-    info: {
-      ...expr.info,
-      type: applySubstitution(expr.info.type, env),
+    info: new Typed({
+      expressionType: applySubstitution(expr.info.expressionType, env),
+      resultingType:
+        expr.info._resultingType &&
+        applySubstitution(expr.info._resultingType, env),
       effect: applySubstitution(expr.info.effect, env)
-    }
+    })
   }));
 }

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -285,7 +285,9 @@ function infer(
       // as we found a variable, and because we lack an
       // 'environment/context', we generate a new type and add an
       // assumption for this variable.
+
       const t = generateUniqueTVar();
+
       const effect = generateUniqueTVar();
       const typedVar = {
         ...expr,
@@ -319,6 +321,7 @@ function infer(
         internalTypes,
         multipleValues
       );
+
       const t = generateUniqueTVar();
       const effect = generateUniqueTVar();
 
@@ -331,7 +334,10 @@ function infer(
             consequent: consequent.result,
             alternative: alternative.result
           },
-          info: singleType(effect, t)
+          info: new Typed({
+            effect,
+            expressionType: t
+          })
         },
         assumptions: [
           ...condition.assumptions,
@@ -489,7 +495,7 @@ function infer(
             })),
             body: bodyInference.result
           },
-          info: singleType(effect, t)
+          info: new Typed({ effect, expressionType: t })
         },
         constraints: [
           ...bodyInference.constraints,
@@ -532,6 +538,9 @@ function infer(
         internalTypes,
         multipleValues
       );
+
+      const effect = generateUniqueTVar();
+
       const t = expandTypeAliases(
         expr.node.typeWithWildcards.instantiate(),
         internalTypes
@@ -544,12 +553,13 @@ function infer(
             ...expr.node,
             value: inferred.result
           },
-          info: singleType(inferred.result.info.effect, t)
+          info: new Typed({ effect, expressionType: t })
         },
         assumptions: inferred.assumptions,
         constraints: [
           ...inferred.constraints,
-          constEqual(inferred.result, t, "expression-type")
+          constEqual(inferred.result, t, "expression-type"),
+          constEffect(inferred.result, effect)
         ]
       };
     }
@@ -573,7 +583,10 @@ function infer(
             body: body.result,
             returning: returning.result
           },
-          info: singleType(effect, returning.result.info.type)
+          info: new Typed({
+            effect,
+            expressionType: returning.result.info.type
+          })
         },
 
         constraints: [
@@ -636,7 +649,7 @@ function infer(
             })),
             defaultCase: defaultCase && defaultCase.result
           },
-          info: singleType(effect, t)
+          info: new Typed({ effect, expressionType: t })
         },
 
         constraints: [

--- a/packages/delisp-core/src/infer.ts
+++ b/packages/delisp-core/src/infer.ts
@@ -771,6 +771,9 @@ function infer(
         assumptions: inference.assumptions
       };
     }
+
+    case "multiple-value-bind":
+      throw new Error(`TODO!`);
   }
 }
 

--- a/packages/delisp-core/src/module.ts
+++ b/packages/delisp-core/src/module.ts
@@ -1,6 +1,6 @@
 import { WithErrors, convert } from "./convert";
 import { readAllFromString } from "./reader";
-import { Module, Syntax } from "./syntax";
+import { Module, Syntax, SDefinition, isDefinition } from "./syntax";
 
 export function createModule(): Module {
   return {
@@ -39,4 +39,17 @@ export function removeModuleTypeDefinition(m: Module, name: string): Module {
       return d.node.tag === "type-alias" ? d.node.alias.name !== name : true;
     })
   };
+}
+
+export function moduleDefinitions<A>(m: Module<A>): Array<SDefinition<A>> {
+  return m.body.filter(isDefinition);
+}
+
+export function moduleDefinitionByName<A>(
+  name: string,
+  m: Module<A>
+): SDefinition<A> | null {
+  return (
+    moduleDefinitions(m).find(def => def.node.variable.name === name) || null
+  );
 }

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -209,6 +209,17 @@ function printExpr(expr: Expression): Doc {
             e.node.value ? indent(concat(line, e.node.value)) : nil
           )
         );
+
+      case "values": {
+        return group(
+          list(
+            groupalign(
+              text("values", "keyword", source),
+              align(...e.node.values)
+            )
+          )
+        );
+      }
     }
   });
 }

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -220,6 +220,9 @@ function printExpr(expr: Expression): Doc {
           )
         );
       }
+
+      case "multiple-value-bind":
+        return nil;
     }
   });
 }

--- a/packages/delisp-core/src/printer.ts
+++ b/packages/delisp-core/src/printer.ts
@@ -222,7 +222,19 @@ function printExpr(expr: Expression): Doc {
       }
 
       case "multiple-value-bind":
-        return nil;
+        return list(
+          text("multiple-value-bind", "keyword", source),
+          space,
+          // List of variables
+          list(
+            join(
+              e.node.variables.map(v => printIdentifier(v.name, source)),
+              space
+            )
+          ),
+          indent(concat(line, e.node.form), 4),
+          indent(concat(line, join(e.node.body, line)))
+        );
     }
   });
 }

--- a/packages/delisp-core/src/sexpr.ts
+++ b/packages/delisp-core/src/sexpr.ts
@@ -49,3 +49,7 @@ export type ASExpr =
   | ASExprList
   | ASExprVector
   | ASExprMap;
+
+export function isSymbolOfName(x: ASExpr, name: string): boolean {
+  return x.tag === "symbol" && x.name === name;
+}

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -117,6 +117,14 @@ export function mapExpr<I, A, B>(
           value: expr.node.value && fn(expr.node.value)
         }
       };
+    case "values":
+      return {
+        ...expr,
+        node: {
+          ...expr.node,
+          values: expr.node.values.map(fn)
+        }
+      };
   }
 }
 
@@ -151,6 +159,8 @@ export function exprFChildren<I, E>(e: ExpressionF<I, E>): E[] {
       ];
     case "case":
       return e.node.value ? [e.node.value] : [];
+    case "values":
+      return e.node.values;
   }
 }
 

--- a/packages/delisp-core/src/syntax-utils.ts
+++ b/packages/delisp-core/src/syntax-utils.ts
@@ -125,6 +125,15 @@ export function mapExpr<I, A, B>(
           values: expr.node.values.map(fn)
         }
       };
+    case "multiple-value-bind":
+      return {
+        ...expr,
+        node: {
+          ...expr.node,
+          form: fn(expr.node.form),
+          body: expr.node.body.map(fn)
+        }
+      };
   }
 }
 
@@ -161,6 +170,8 @@ export function exprFChildren<I, E>(e: ExpressionF<I, E>): E[] {
       return e.node.value ? [e.node.value] : [];
     case "values":
       return e.node.values;
+    case "multiple-value-bind":
+      return [e.node.form, ...e.node.body];
   }
 }
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -113,6 +113,13 @@ interface SValuesF<E> {
   values: E[];
 }
 
+interface SMultipleValueBindF<E> {
+  tag: "multiple-value-bind";
+  variables: Identifier[];
+  form: E;
+  body: E[];
+}
+
 interface SUnknownF<_E> {
   tag: "unknown";
 }
@@ -132,6 +139,7 @@ type AnyExpressionF<I = {}, E = Expression<I>> =
   | SMatchF<E>
   | SCaseTagF<E>
   | SValuesF<E>
+  | SMultipleValueBindF<E>
   | SUnknownF<E>;
 
 interface Node<I, E> {
@@ -170,6 +178,9 @@ export interface SMatch<I = {}> extends Node<I, SMatchF<Expression<I>>> {}
 export interface SCaseTag<I = {}> extends Node<I, SCaseTagF<Expression<I>>> {}
 
 export interface SValues<I = {}> extends Node<I, SValuesF<Expression<I>>> {}
+
+export interface SMultipleValueBind<I = {}>
+  extends Node<I, SMultipleValueBindF<Expression<I>>> {}
 
 export interface SUnknown<I = {}> extends Node<I, SUnknownF<Expression<I>>> {}
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -108,6 +108,11 @@ interface SCaseTagF<E> {
   value?: E;
 }
 
+interface SValuesF<E> {
+  tag: "values";
+  values: E[];
+}
+
 interface SUnknownF<_E> {
   tag: "unknown";
 }
@@ -126,6 +131,7 @@ type AnyExpressionF<I = {}, E = Expression<I>> =
   | SDoBlockF<E>
   | SMatchF<E>
   | SCaseTagF<E>
+  | SValuesF<E>
   | SUnknownF<E>;
 
 interface Node<I, E> {
@@ -162,6 +168,8 @@ export interface SDoBlock<I = {}> extends Node<I, SDoBlockF<Expression<I>>> {}
 export interface SMatch<I = {}> extends Node<I, SMatchF<Expression<I>>> {}
 
 export interface SCaseTag<I = {}> extends Node<I, SCaseTagF<Expression<I>>> {}
+
+export interface SValues<I = {}> extends Node<I, SValuesF<Expression<I>>> {}
 
 export interface SUnknown<I = {}> extends Node<I, SUnknownF<Expression<I>>> {}
 

--- a/packages/delisp-core/src/syntax.ts
+++ b/packages/delisp-core/src/syntax.ts
@@ -237,7 +237,54 @@ export interface Module<EInfo = {}, SInfo = {}> {
   body: Array<Syntax<EInfo, SInfo>>;
 }
 
-export interface Typed {
-  type: Type;
+export class Typed {
   effect: Type;
+
+  // Declared resulting type. If undefined, we'll just return the
+  // expression type. This should speed up as we avoid operating on
+  // double the amount of types.
+  _resultingType: Type | undefined;
+  expressionType: Type;
+
+  constructor({
+    expressionType,
+    resultingType,
+    effect
+  }: {
+    expressionType: Type;
+    resultingType?: Type;
+    effect: Type;
+  }) {
+    this.expressionType = expressionType;
+    this._resultingType = resultingType;
+    this.effect = effect;
+  }
+
+  // The `resultingType` is used as the resulting type in the parent
+  // expression.
+  //
+  // Note that this type DOES NOT need to be equal to the type of the
+  // expression itself. For instance, in the presence of multiple
+  // values:
+  //
+  //   (+ 1 (values 1 2))
+  //
+  // (values 1 2) will have type `(values 1 2)`, however the type number
+  // is returned to the parent expression.
+  //
+  // And the other way around, in:
+  //
+  //   (lambda (x) x)
+  //
+  // x as an expression has type `a`, but `(values a)` is returned to
+  // the parent function.
+  //
+  get resultingType() {
+    return this._resultingType || this.expressionType;
+  }
+
+  // Compatibility
+  get type() {
+    return this.resultingType;
+  }
 }

--- a/packages/delisp-core/src/type-printer.spec.ts
+++ b/packages/delisp-core/src/type-printer.spec.ts
@@ -1,4 +1,12 @@
-import { tEffect, tCases, tVar, tVoid } from "./types";
+import {
+  tFn,
+  tMultiValuedFunction,
+  tValues,
+  tEffect,
+  tCases,
+  tVar,
+  tVoid
+} from "./types";
 import { printType } from "./type-printer";
 
 describe("Type printer", () => {
@@ -24,5 +32,26 @@ describe("Type printer", () => {
         false
       )
     ).toBe("(cases (:a a) :b c)");
+  });
+
+  test("print function types returning a single value", () => {
+    expect(printType(tFn([], tEffect([]), tVar("a")), false)).toBe(
+      "(-> (effect) a)"
+    );
+    expect(
+      printType(
+        tMultiValuedFunction([], tEffect([]), tValues([tVar("a")])),
+        false
+      )
+    ).toBe("(-> (effect) a)");
+  });
+
+  test("print function types returning multiple values", () => {
+    expect(
+      printType(
+        tMultiValuedFunction([], tEffect([]), tValues([tVar("a"), tVar("a")])),
+        false
+      )
+    ).toBe("(-> (effect) (values a a))");
   });
 });

--- a/packages/delisp-core/src/type-printer.ts
+++ b/packages/delisp-core/src/type-printer.ts
@@ -45,6 +45,9 @@ function printValuesType(fnout: Type, simplify = false): string {
           return _printType(field.labelType);
         })
         .join(" ") +
+      (row.extends.node.tag === "empty-row"
+        ? ""
+        : "| " + _printType(row.extends)) +
       ")"
     );
   }

--- a/packages/delisp-core/src/type-printer.ts
+++ b/packages/delisp-core/src/type-printer.ts
@@ -29,9 +29,13 @@ function printValuesType(
   simplify = false
 ): string {
   const row = normalizeRow(fnout);
-
   // primary value only
-  if (simplify && row.fields.length === 1 && row.fields[0].label === "0") {
+  if (
+    simplify &&
+    row.fields.length === 1 &&
+    row.fields[0].label === "0" &&
+    row.extends.node.tag === "empty-row"
+  ) {
     return _printType(row.fields[0].labelType, normalizeVar);
   } else {
     // full form (values a b c ...)
@@ -45,7 +49,7 @@ function printValuesType(
         .join(" ") +
       (row.extends.node.tag === "empty-row"
         ? ""
-        : "| " + _printType(row.extends, normalizeVar)) +
+        : " | " + _printType(row.extends, normalizeVar)) +
       ")"
     );
   }

--- a/packages/delisp-core/src/type-utils.ts
+++ b/packages/delisp-core/src/type-utils.ts
@@ -9,9 +9,18 @@ import {
   emptyRow,
   TypeSchema,
   TConstant,
-  TApplication
+  TApplication,
+  TVar
 } from "./types";
 import { unique } from "./utils";
+
+export function isTVar(t: Type): t is TVar {
+  return t.node.tag === "type-variable";
+}
+
+export function onlyPrimaryType(t: Type): Type {
+  return { ...t, node: { ...t.node } };
+}
 
 export function isFunctionType(t: Type): t is TApplication {
   return (
@@ -39,7 +48,12 @@ export function mapType<A, B>(type: TypeF<A>, fn: (x: A) => B): TypeF<B> {
     case "constant":
     case "type-variable":
     case "empty-row":
-      return { node: type.node };
+      return {
+        ...type,
+        node: {
+          ...type.node
+        }
+      };
     case "application":
       return {
         node: {
@@ -91,7 +105,16 @@ export function applySubstitution(t: Type, env: Substitution): Type {
 // Return user defined types
 export function listTypeConstants(type: Type): TConstant[] {
   return foldType(type, t => {
-    return t.node.tag === "constant" ? [{ node: t.node }] : typeChildren(t);
+    return t.node.tag === "constant"
+      ? [
+          {
+            node: {
+              ...t.node,
+              nextType: undefined
+            }
+          }
+        ]
+      : typeChildren(t);
   });
 }
 

--- a/packages/delisp-core/src/typescript-generation.ts
+++ b/packages/delisp-core/src/typescript-generation.ts
@@ -137,7 +137,9 @@ export function generateTSDeclaration(
   switch (s.node.tag) {
     case "definition": {
       const varname = identifierToJS(s.node.variable.name);
-      const typ = generateTSType(generalize(s.node.value.info.type, []));
+      const typ = generateTSType(
+        generalize(s.node.value.info.resultingType, [])
+      );
       return `declare const ${varname}: ${typ};`;
     }
     case "type-alias": {

--- a/packages/delisp-core/src/unify.ts
+++ b/packages/delisp-core/src/unify.ts
@@ -13,7 +13,7 @@
  */
 
 import { generateUniqueTVar } from "./type-generate";
-import { Substitution } from "./type-utils";
+import { isTVar, Substitution } from "./type-utils";
 import { Type, RExtension, tRowExtension, TVar } from "./types";
 
 interface UnifySuccess {
@@ -199,9 +199,7 @@ function unifyRow(
   const rewriteResult = rewriteRowForLabel(
     row2,
     row1.node.label,
-    tail.node.tag === "type-variable"
-      ? { ...tail, node: tail.node }
-      : undefined,
+    isTVar(tail) ? tail : undefined,
     ctx
   );
   if (!rewriteResult) {

--- a/packages/delisp-runtime/src/boolean.ts
+++ b/packages/delisp-runtime/src/boolean.ts
@@ -3,17 +3,17 @@ import { Primitives } from "./types";
 const booleanPrims: Primitives = {
   not: {
     type: "(-> boolean _ boolean)",
-    value: (a: boolean) => !a
+    value: (_values: unknown, a: boolean) => !a
   },
 
   and: {
     type: "(-> boolean boolean _ boolean)",
-    value: (a: boolean, b: boolean) => a && b
+    value: (_values: unknown, a: boolean, b: boolean) => a && b
   },
 
   or: {
     type: "(-> boolean boolean _ boolean)",
-    value: (a: boolean, b: boolean) => a || b
+    value: (_values: unknown, a: boolean, b: boolean) => a || b
   }
 };
 

--- a/packages/delisp-runtime/src/index.ts
+++ b/packages/delisp-runtime/src/index.ts
@@ -84,3 +84,11 @@ export function mvbind(x: unknown, fn: (...xs: unknown[]) => unknown): unknown {
     return fn(x);
   }
 }
+
+export function id(x: unknown): unknown {
+  return x;
+}
+
+export function bindPrimaryValue(fn: Function): Function {
+  return (...args: unknown[]) => fn(id, ...args);
+}

--- a/packages/delisp-runtime/src/index.ts
+++ b/packages/delisp-runtime/src/index.ts
@@ -57,3 +57,22 @@ export function fst<A, B>(pair: Pair<A, B>): A {
 export function snd<A, B>(pair: Pair<A, B>): B {
   return pair.snd;
 }
+
+//
+// Multiple values
+//
+
+export class MultipleValues {
+  values: unknown[];
+  constructor(values: unknown[]) {
+    this.values = values;
+  }
+}
+
+export function values(...x: unknown[]): MultipleValues {
+  return new MultipleValues(x);
+}
+
+export function primaryValue(x: MultipleValues): unknown {
+  return x instanceof MultipleValues ? x.values[0] : x;
+}

--- a/packages/delisp-runtime/src/index.ts
+++ b/packages/delisp-runtime/src/index.ts
@@ -76,3 +76,11 @@ export function values(...x: unknown[]): MultipleValues {
 export function primaryValue(x: MultipleValues): unknown {
   return x instanceof MultipleValues ? x.values[0] : x;
 }
+
+export function mvbind(x: unknown, fn: (...xs: unknown[]) => unknown): unknown {
+  if (x instanceof MultipleValues) {
+    return fn.apply(null, x.values);
+  } else {
+    return fn(x);
+  }
+}

--- a/packages/delisp-runtime/src/index.ts
+++ b/packages/delisp-runtime/src/index.ts
@@ -62,33 +62,13 @@ export function snd<A, B>(pair: Pair<A, B>): B {
 // Multiple values
 //
 
-export class MultipleValues {
-  values: unknown[];
-  constructor(values: unknown[]) {
-    this.values = values;
-  }
-}
-
-export function values(...x: unknown[]): MultipleValues {
-  return new MultipleValues(x);
-}
-
-export function primaryValue(x: MultipleValues): unknown {
-  return x instanceof MultipleValues ? x.values[0] : x;
-}
-
-export function mvbind(x: unknown, fn: (...xs: unknown[]) => unknown): unknown {
-  if (x instanceof MultipleValues) {
-    return fn.apply(null, x.values);
-  } else {
-    return fn(x);
-  }
-}
-
-export function id(x: unknown): unknown {
+export function primaryValue(x: unknown, ..._others: unknown[]): unknown {
   return x;
 }
 
+// bit of a hack for toplevel function calls
+export const values = primaryValue;
+
 export function bindPrimaryValue(fn: Function): Function {
-  return (...args: unknown[]) => fn(id, ...args);
+  return (...args: unknown[]) => fn(primaryValue, ...args);
 }

--- a/packages/delisp-runtime/src/primitives.ts
+++ b/packages/delisp-runtime/src/primitives.ts
@@ -7,7 +7,7 @@ import stringPrims from "./string";
 const prims: Primitives = {
   "<": {
     type: "(-> number number _ boolean)",
-    value: (a: number, b: number) => a < b
+    value: (_values: unknown, a: number, b: number) => a < b
   },
 
   unknown: {

--- a/packages/delisp-runtime/src/string.ts
+++ b/packages/delisp-runtime/src/string.ts
@@ -11,14 +11,14 @@ function validBoundingIndex(str: string, start: number, end: number) {
 const stringPrims: Primitives = {
   "string-ref": {
     type: "(-> string number _ string)",
-    value: (str: string, k: number) => {
+    value: (_values: unknown, str: string, k: number) => {
       validBoundingIndex(str, k, k + 1);
       return str[k];
     }
   },
   substring: {
     type: "(-> string number number _ string)",
-    value: (str: string, start: number, end: number) => {
+    value: (_values: unknown, str: string, start: number, end: number) => {
       validBoundingIndex(str, start, end);
       return str.slice(start, end);
     }

--- a/packages/delisp-runtime/src/vector.ts
+++ b/packages/delisp-runtime/src/vector.ts
@@ -8,12 +8,12 @@ const vectorPrims: Primitives = {
 
   cons: {
     type: "(-> a [a] _ [a])",
-    value: <T>(a: T, list: T[]): T[] => [a, ...list]
+    value: <T>(_values: unknown, a: T, list: T[]): T[] => [a, ...list]
   },
 
   first: {
     type: "(-> [a] (effect exp | _) a)",
-    value: <T>(list: T[]): T => {
+    value: <T>(_values: unknown, list: T[]): T => {
       if (list.length > 0) {
         return list[0];
       } else {
@@ -24,7 +24,7 @@ const vectorPrims: Primitives = {
 
   rest: {
     type: "(-> [a] (effect exp | _) [a])",
-    value: <T>(list: T[]): T[] => {
+    value: <T>(_values: unknown, list: T[]): T[] => {
       if (list.length > 0) {
         const [, ...rest] = list;
         return rest;
@@ -36,7 +36,7 @@ const vectorPrims: Primitives = {
 
   "empty?": {
     type: "(-> [a] _ boolean)",
-    value: <T>(list: T[]): boolean => list.length === 0
+    value: <T>(_values: unknown, list: T[]): boolean => list.length === 0
   }
 };
 

--- a/packages/delisp/src/cmd-repl.ts
+++ b/packages/delisp/src/cmd-repl.ts
@@ -21,6 +21,7 @@ import {
   removeModuleTypeDefinition,
   moduleDefinitionByName,
   collectConvertErrors,
+  defaultEnvironment,
   Type
 } from "@delisp/core";
 
@@ -168,7 +169,7 @@ const delispEval = (syntax: Syntax): DelispEvalResult => {
 
     const expressionResult =
       typedModule && isExpression(syntax)
-        ? inferExpressionInModule(syntax, typedModule)
+        ? inferExpressionInModule(syntax, typedModule, defaultEnvironment, true)
         : undefined;
     typedExpression = expressionResult && expressionResult.typedExpression;
 

--- a/packages/delisp/src/cmd-repl.ts
+++ b/packages/delisp/src/cmd-repl.ts
@@ -1,6 +1,6 @@
 import * as fs from "./fs-helpers";
 import path from "path";
-import { Pair, TaggedValue, MultipleValues } from "@delisp/runtime";
+import { Pair, TaggedValue } from "@delisp/runtime";
 
 import { CommandModule } from "yargs";
 
@@ -225,8 +225,6 @@ function printValue(result: any): string {
     return "none";
   } else if (result === null) {
     return "#<null>";
-  } else if (result instanceof MultipleValues) {
-    return `(values${result.values.map(v => " " + printValue(v)).join("")})`;
   } else if (result instanceof TaggedValue) {
     if (result.value === undefined) {
       return `(case ${result.tag})`;


### PR DESCRIPTION
Multiple values can be introduced by the new special form

`(values 1 2)`

The first value is called primary value. Non-primary values are discarded when composed by default:

`(+ 2 (values 2 "foo"))  => 4`

However, the last form of bodies will usually return all values generated by the last expression:

```lisp
(the (-> a _ (values a a))
  (lambda (x) (values x x))
```

Note that the type `(values a)` is actually uninhabited. There is no runtime value can be accessed with such a type.  Instead, most of the other forms will destructure `(values x y...)` to extract the primary value, including function application.

